### PR TITLE
Adding checks when some foreign keys are duplicated.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require" : {
         "php" : ">=7.1",
         "mouf/magic-query" : "^1.2.1",
-        "mouf/schema-analyzer": "^1.1",
+        "mouf/schema-analyzer": "^1.1.1",
         "doctrine/dbal": "~2.5",
         "psr/log": "~1.0",
         "doctrine/inflector": "~1.0",

--- a/tests/Fixtures/tdbmunittest.sql
+++ b/tests/Fixtures/tdbmunittest.sql
@@ -352,6 +352,10 @@ ALTER TABLE `users`
 ADD CONSTRAINT `users_ibfk_1` FOREIGN KEY (`country_id`) REFERENCES `country` (`id`),
 ADD CONSTRAINT `users_ibfk_2` FOREIGN KEY (`id`) REFERENCES `contact` (`id`);
 
+-- This is not a typo, we are willingly creating 2 constraints on the same column to see if TDBM behaves correctly in these conditions.
+ALTER TABLE `users`
+ADD CONSTRAINT `users_ibfk_3` FOREIGN KEY (`country_id`) REFERENCES `country` (`id`);
+
 --
 -- Constraints for table `users`
 --


### PR DESCRIPTION
When some foreign keys are declared in duplicate, we are facing double declaration of methods.
This patch fixes the problem by ignoring the additional redundant foreign keys.