### PR TITLE
Feature: raw sql

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "mouf/magic-query" : "^1.2.1",
+        "mouf/magic-query" : "^1.2.3",
         "mouf/schema-analyzer": "^1.1.1",
         "doctrine/dbal": "~2.5",
         "psr/log": "~1.0",

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -541,6 +541,45 @@ class ProductDao extends AbstractProductDao {
 }
 ```
 
+###Writing the whole SQL
+
+In the case of complex queries, you may want to use method `findFromRawSql`, allowing you to write the whole query.
+For instance, a query using a `GROUP BY` statement will not be supported by method `findFromSql`.
+```php
+class CountryDao extends AbstractCountryDao
+{
+    /**
+     * Returns the list of countries ordered by their users count (descending)
+     * @return Country[]
+     */
+    public function getCountriesByUserCount()
+    {
+        $sql = <<<SQL
+SELECT country.*
+FROM country
+LEFT JOIN users ON users.country_id = country.id
+GROUP BY country.id
+ORDER BY COUNT(users.id) DESC
+SQL;
+
+        return $this->findFromRawSql($sql);
+    }
+}
+```
+The SQL query will actually be formatted, so that the result fetched is well formed for bean reconstruction. The only
+condition you will have to respect is the presence of `main_table.*` in the `SELECT` statement (as well as the inherited
+tables in case of tables inheritance; refer to the page about [modeling inheritance](modeling_inheritance.md) for more
+details).
+You may also provide the SQL code for the corresponding `COUNT` query; if you don't it will automatically be computed,
+even when using `GROUP BY` and `HAVING` statements.
+In the example above, the count SQL computed would be:
+```sql
+SELECT COUNT(DISTINCT country.id)
+FROM country
+LEFT JOIN users ON users.country_id = country.id
+```
+(the `GROUP BY x` statement is translated as a `COUNT(DISTINCT x)`)
+
 Ordering
 --------
 

--- a/src/InnerResultIterator.php
+++ b/src/InnerResultIterator.php
@@ -171,13 +171,17 @@ class InnerResultIterator implements \Iterator, \Countable, \ArrayAccess
      */
     public function next()
     {
-        $row = $this->statement->fetch(\PDO::FETCH_NUM);
+        $row = $this->statement->fetch(\PDO::FETCH_LAZY);
         if ($row) {
 
             // array<tablegroup, array<table, array<column, value>>>
             $beansData = [];
-            foreach ($row as $i => $value) {
-                $columnDescriptor = $this->columnDescriptors[$i];
+            foreach ($row as $key => $value) {
+                if (!isset($this->columnDescriptors[$key])) {
+                    continue;
+                }
+
+                $columnDescriptor = $this->columnDescriptors[$key];
 
                 if ($columnDescriptor['tableGroup'] === null) {
                     // A column can have no tableGroup (if it comes from an ORDER BY expression)

--- a/src/QueryFactory/AbstractQueryFactory.php
+++ b/src/QueryFactory/AbstractQueryFactory.php
@@ -109,7 +109,7 @@ abstract class AbstractQueryFactory implements QueryFactory
                 } elseif ($orderByColumn['type'] === 'expr') {
                     $sortColumnName = 'sort_column_'.$sortColumn;
                     $columnsList[] = $orderByColumn['expr'].' as '.$sortColumnName;
-                    $columnDescList[] = [
+                    $columnDescList[$sortColumnName] = [
                         'tableGroup' => null,
                     ];
                     ++$sortColumn;
@@ -141,7 +141,7 @@ abstract class AbstractQueryFactory implements QueryFactory
         foreach ($allFetchedTables as $table) {
             foreach ($this->schema->getTable($table)->getColumns() as $column) {
                 $columnName = $column->getName();
-                $columnDescList[] = [
+                $columnDescList[$table.'____'.$columnName] = [
                     'as' => $table.'____'.$columnName,
                     'table' => $table,
                     'column' => $columnName,

--- a/src/QueryFactory/FindObjectsFromRawSqlQueryFactory.php
+++ b/src/QueryFactory/FindObjectsFromRawSqlQueryFactory.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace TheCodingMachine\TDBM\QueryFactory;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Schema;
+use TheCodingMachine\TDBM\TDBMException;
+use TheCodingMachine\TDBM\TDBMService;
+use TheCodingMachine\TDBM\UncheckedOrderBy;
+use PHPSQLParser\PHPSQLCreator;
+use PHPSQLParser\PHPSQLParser;
+
+/**
+ * This class is in charge of formatting the SQL passed to findObjectsFromRawSql method.
+ */
+class FindObjectsFromRawSqlQueryFactory implements QueryFactory
+{
+    /**
+     * @var array[]
+     */
+    protected $columnDescriptors;
+    /**
+     * @var Schema
+     */
+    private $schema;
+    /**
+     * @var string
+     */
+    private $sql;
+    /**
+     * @var string
+     */
+    private $sqlCount;
+    /**
+     * @var string
+     */
+    private $processedSql;
+    /**
+     * @var string
+     */
+    private $processedSqlCount;
+    /**
+     * @var TDBMService
+     */
+    private $tdbmService;
+    /**
+     * @var string
+     */
+    private $mainTable;
+
+    /**
+     * FindObjectsFromRawSqlQueryFactory constructor.
+     * @param TDBMService $tdbmService
+     * @param Schema $schema
+     * @param string $mainTable
+     * @param string $sql
+     * @param string $sqlCount
+     */
+    public function __construct(TDBMService $tdbmService, Schema $schema, string $mainTable, string $sql, string $sqlCount = null)
+    {
+        $this->sql = $sql;
+        $this->sqlCount = $sqlCount;
+        $this->tdbmService = $tdbmService;
+        $this->schema = $schema;
+        $this->mainTable = $mainTable;
+
+        $this->compute();
+    }
+
+    public function sort($orderBy)
+    {
+        throw new TDBMException('sort not supported for raw sql queries');
+    }
+
+    public function getMagicSql(): string
+    {
+        return $this->processedSql;
+    }
+
+    public function getMagicSqlCount(): string
+    {
+        return $this->processedSqlCount;
+    }
+
+    public function getColumnDescriptors(): array
+    {
+        return $this->columnDescriptors;
+    }
+
+    protected function compute()
+    {
+        $parser = new PHPSQLParser();
+        $generator = new PHPSQLCreator();
+        $parsedSql = $parser->parse($this->sql);
+
+        // 1: let's reformat the SELECT and construct our columns
+        list($select, $columnDescriptors) = $this->formatSelect($parsedSql['SELECT']);
+        $parsedSql['SELECT'] = $select;
+        $this->processedSql = $generator->create($parsedSql);
+        $this->columnDescriptors = $columnDescriptors;
+
+        // 2: let's compute the count query if needed
+        if ($this->sqlCount === null) {
+            $parsedSqlCount = $this->generateParsedSqlCount($parsedSql);
+            $this->processedSqlCount = $generator->create($parsedSqlCount);
+        } else {
+            $this->processedSqlCount = $this->sqlCount;
+        }
+    }
+
+    private function formatSelect($baseSelect)
+    {
+        $relatedTables = $this->tdbmService->_getRelatedTablesByInheritance($this->mainTable);
+        $tableGroup = $this->getTableGroupName($relatedTables);
+
+        $connection = $this->tdbmService->getConnection();
+        $formattedSelect = [];
+        $columnDescritors = [];
+        $fetchedTables = [];
+
+        foreach ($baseSelect as $entry) {
+            if ($entry['expr_type'] !== 'colref') {
+                $formattedSelect[] = $entry;
+                continue;
+            }
+
+            $noQuotes = $entry['no_quotes'];
+            if ($noQuotes['delim'] != '.' || count($noQuotes['parts']) !== 2) {
+                $formattedSelect[] = $entry;
+                continue;
+            }
+
+            $tableName = $noQuotes['parts'][0];
+            if (!in_array($tableName, $relatedTables)) {
+                $formattedSelect[] = $entry;
+                continue;
+            }
+
+            $columnName = $noQuotes['parts'][1];
+            if ($columnName !== '*') {
+                $formattedSelect[] = $entry;
+                continue;
+            }
+
+            $table = $this->schema->getTable($tableName);
+            foreach ($table->getColumns() as $column) {
+                $columnName = $column->getName();
+                $alias = "{$tableName}____{$columnName}";
+                $formattedSelect[] = [
+                    'expr_type' => 'colref',
+                    'base_expr' => $connection->quoteIdentifier($tableName).'.'.$connection->quoteIdentifier($columnName),
+                    'no_quotes' => [
+                        'delim' => '.',
+                        'parts' => [
+                            $tableName,
+                            $columnName
+                        ]
+                    ],
+                    'alias' => [
+                        'as' => true,
+                        'name' => $alias,
+                    ]
+                ];
+
+                $columnDescritors[$alias] = [
+                    'as' => $alias,
+                    'table' => $tableName,
+                    'column' => $columnName,
+                    'type' => $column->getType(),
+                    'tableGroup' => $tableGroup,
+                ];
+            }
+            $fetchedTables[] = $tableName;
+        }
+
+        $missingTables = array_diff($relatedTables, $fetchedTables);
+        if (!empty($missingTables)) {
+            throw new TDBMException('Missing tables '.implode(', ', $missingTables).' in SELECT statement');
+        }
+
+        for ($i = 0; $i < count($formattedSelect) - 1; $i++) {
+            $formattedSelect[$i]['delim'] = ',';
+        }
+        return [$formattedSelect, $columnDescritors];
+    }
+
+    private function generateParsedSqlCount($parsedSql)
+    {
+        if (isset($parsedSql['ORDER'])) {
+            unset($parsedSql['ORDER']);
+        }
+
+        if (!isset($parsedSql['GROUP'])) {
+            // most simple case:no GROUP BY in query
+            return $this->generateSimpleSqlCount($parsedSql);
+        } elseif (!isset($parsedSql['HAVING'])) {
+            // GROUP BY without HAVING statement: let's COUNT the DISTINCT grouped columns
+            return $this->generateGroupedSqlCount($parsedSql);
+        } else {
+            // GROUP BY with a HAVING statement: we'll have to wrap the query
+            return $this->generateWrappedSqlCount($parsedSql);
+        }
+    }
+
+    private function generateSimpleSqlCount($parsedSql)
+    {
+        return [[
+            'expr_type' => 'aggregate_function',
+            'alias' => false,
+            'base_expr' => 'COUNT',
+            'sub_tree' => $parsedSql['SELECT'],
+            'delim' => false,
+        ]];
+    }
+
+    private function generateGroupedSqlCount($parsedSql)
+    {
+        $group = $parsedSql['GROUP'];
+        unset($parsedSql['GROUP']);
+        $parsedSql['SELECT'] = [[
+            'expr_type' => 'aggregate_function',
+            'alias' => false,
+            'base_expr' => 'COUNT',
+            'sub_tree' => array_merge([[
+                'expr_type' => 'reserved',
+                'base_expr' => 'DISTINCT',
+                'delim' => ','
+            ]], $group),
+            'delim' => false,
+        ]];
+        return $parsedSql;
+    }
+
+    private function generateWrappedSqlCount($parsedSql)
+    {
+        return [
+            'SELECT' => [[
+                'expr_type' => 'aggregate_function',
+                'alias' => false,
+                'base_expr' => 'COUNT',
+                'sub_tree' => [
+                    [
+                        'expr_type' => 'colref',
+                        'base_expr' => '*',
+                        'sub_tree' => false
+                    ]
+                ],
+                'delim' => false,
+            ]],
+            'FROM' => [[
+                'expr_type' => 'subquery',
+                'alias' => [
+                    'as' => true,
+                    'name' => '____query'
+                ],
+                'sub_tree' => $parsedSql,
+            ]]
+        ];
+    }
+
+    protected function getTableGroupName(array $relatedTables)
+    {
+        sort($relatedTables);
+        return implode('_``_', $relatedTables);
+    }
+}

--- a/src/Utils/TDBMDaoGenerator.php
+++ b/src/Utils/TDBMDaoGenerator.php
@@ -380,6 +380,25 @@ class $baseClassName
     }
 
     /**
+     * Get a list of $beanClassWithoutNameSpace from a SQL query.
+     * Unlike the `find` and `findFromSql` methods, here you can pass the whole \$sql query.
+     *
+     * You should not put an alias on the main table name, and select its columns using `*`. So the SELECT part of you \$sql should look like:
+     *
+     *   \"SELECT $tableName.* FROM ...\"
+     *
+     * @param string \$sql The sql query
+     * @param array \$parameters The parameters associated with the filter
+     * @param string \$countSql The count sql query (automatically computed if not provided)
+     * @param int \$mode Either TDBMService::MODE_ARRAY or TDBMService::MODE_CURSOR (for large datasets). Defaults to TDBMService::MODE_ARRAY.
+     * @return {$beanClassWithoutNameSpace}[]|ResultIterator|ResultArray
+     */
+    protected function findFromRawSql(\$sql, array \$parameters = [], \$countSql = null, \$mode = null) : iterable
+    {
+        return \$this->tdbmService->findObjectsFromRawSql('$tableName', \$sql, \$parameters, \$mode, null, \$countSql);
+    }
+
+    /**
      * Get a single $beanClassWithoutNameSpace specified by its filters.
      *
      * @param mixed \$filter The filter bag (see TDBMService::findObjects for complete description)

--- a/tests/Dao/TestCountryDao.php
+++ b/tests/Dao/TestCountryDao.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace TheCodingMachine\TDBM\Dao;
+
+use Porpaginas\Result;
+use TheCodingMachine\TDBM\Test\Dao\Bean\CountryBean;
+use TheCodingMachine\TDBM\Test\Dao\Generated\CountryBaseDao;
+
+/**
+ * The CountryDao class will maintain the persistence of CountryBean class into the country table.
+ */
+class TestCountryDao extends CountryBaseDao
+{
+    /**
+     * @return CountryBean[]|Result
+     */
+    public function getCountriesByUserCount()
+    {
+        $sql = <<<SQL
+SELECT country.*
+FROM country
+LEFT JOIN users ON users.country_id = country.id
+GROUP BY country.id
+ORDER BY COUNT(users.id) DESC
+SQL;
+
+        return $this->findFromRawSql($sql);
+    }
+}

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -23,6 +23,7 @@ namespace TheCodingMachine\TDBM;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Mouf\Database\SchemaAnalyzer\SchemaAnalyzer;
+use TheCodingMachine\TDBM\Dao\TestCountryDao;
 use TheCodingMachine\TDBM\Dao\TestRoleDao;
 use TheCodingMachine\TDBM\Dao\TestUserDao;
 use TheCodingMachine\TDBM\Test\Dao\AllNullableDao;
@@ -645,6 +646,20 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
         $this->assertCount(2, $roles);
         $this->assertEquals('Singers', $roles[0]->getName());
         $this->assertEquals('Admins', $roles[1]->getName());
+    }
+
+    /**
+     * @depends testDaoGeneration
+     */
+    public function testFindFromRawSqlOrderByUserCount()
+    {
+        $countryDao = new TestCountryDao($this->tdbmService);
+        $countries = $countryDao->getCountriesByUserCount();
+
+        $this->assertCount(4, $countries);
+        for ($i = 1; $i < count($countries); $i++) {
+            $this->assertLessThanOrEqual($countries[$i - 1]->getUsers()->count(), $countries[$i]->getUsers()->count());
+        }
     }
 
     /**


### PR DESCRIPTION
Added class `FindObjectsFromRawSqlQueryFactory` to handle object retrieving on full SQL queries.

It's particularly usefull on complex queries using `GROUP BY` and so on

For example:
```mysql
SELECT country.* AS ids
FROM country
JOIN users ON country.id= users.country_id
GROUP BY country.id
ORDER BY COUNT(users.id);
```

*Note: selecting the columns group `*` from the main table is mandatory!*