### PR TITLE
A reference to a non primary key fails

### DIFF
--- a/src/DbRow.php
+++ b/src/DbRow.php
@@ -266,9 +266,14 @@ class DbRow
                 $values[] = $this->dbRow[$column];
             }
 
-            $filter = array_combine($this->tdbmService->getPrimaryKeyColumns($fk->getForeignTableName()), $values);
+            $filter = array_combine($fk->getUnquotedForeignColumns(), $values);
 
-            return $this->tdbmService->findObjectByPk($fk->getForeignTableName(), $filter, [], true);
+            // If the foreign key points to the primary key, let's use findObjectByPk
+            if ($this->tdbmService->getPrimaryKeyColumns($fk->getForeignTableName()) === $fk->getUnquotedForeignColumns()) {
+                return $this->tdbmService->findObjectByPk($fk->getForeignTableName(), $filter, [], true);
+            } else {
+                return $this->tdbmService->findObject($fk->getForeignTableName(), $filter);
+            }
         }
     }
 

--- a/tests/TDBMAbstractServiceTest.php
+++ b/tests/TDBMAbstractServiceTest.php
@@ -333,7 +333,7 @@ abstract class TDBMAbstractServiceTest extends \PHPUnit_Framework_TestCase
             ->column('from')->string(50)
             ->column('to')->string(50)->unique();
 
-        $toSchema->getTable('ref_no_prim_key')->addForeignKeyConstraint('ref_no_prim_key', ['from'], ['to']);
+        $toSchema->getTable($connection->quoteIdentifier('ref_no_prim_key'))->addForeignKeyConstraint('ref_no_prim_key', [$connection->quoteIdentifier('from')], [$connection->quoteIdentifier('to')]);
 
         $sqlStmts = $toSchema->getMigrateFromSql($fromSchema, $connection->getDatabasePlatform());
 

--- a/tests/TDBMAbstractServiceTest.php
+++ b/tests/TDBMAbstractServiceTest.php
@@ -327,6 +327,13 @@ abstract class TDBMAbstractServiceTest extends \PHPUnit_Framework_TestCase
                 ->addUniqueIndex([$connection->quoteIdentifier('login')], 'users_login_idx_2');
         }
 
+        // A table with a foreign key that references a non primary key.
+        $db->table('ref_no_prim_key')
+            ->column('id')->integer()->primaryKey()->autoIncrement()->comment('@Autoincrement')
+            ->column('from')->string(50)
+            ->column('to')->string(50)->unique();
+
+        $toSchema->getTable('ref_no_prim_key')->addForeignKeyConstraint('ref_no_prim_key', ['from'], ['to']);
 
         $sqlStmts = $toSchema->getMigrateFromSql($fromSchema, $connection->getDatabasePlatform());
 
@@ -467,6 +474,11 @@ abstract class TDBMAbstractServiceTest extends \PHPUnit_Framework_TestCase
         self::insert($connection, 'users_roles', [
             'user_id' => 3,
             'role_id' => 2,
+        ]);
+
+        self::insert($connection, 'ref_no_prim_key', [
+            'from' => 'foo',
+            'to' => 'foo',
         ]);
     }
 

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -49,6 +49,7 @@ use TheCodingMachine\TDBM\Test\Dao\ContactDao;
 use TheCodingMachine\TDBM\Test\Dao\CountryDao;
 use TheCodingMachine\TDBM\Test\Dao\DogDao;
 use TheCodingMachine\TDBM\Test\Dao\Generated\UserBaseDao;
+use TheCodingMachine\TDBM\Test\Dao\RefNoPrimKeyDao;
 use TheCodingMachine\TDBM\Test\Dao\RoleDao;
 use TheCodingMachine\TDBM\Test\Dao\UserDao;
 use TheCodingMachine\TDBM\Utils\PathFinder\NoPathFoundException;
@@ -1471,5 +1472,13 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
 
         // The name should not have been saved because the transaction of the previous test should have rollbacked.
         $this->assertNotSame('Bismark', $boatBean->getName());
+    }
+
+    public function testForeignKeyPointingToNonPrimaryKey()
+    {
+        $dao = new RefNoPrimKeyDao($this->tdbmService);
+        $bean = $dao->getById(1);
+
+        $this->assertSame('foo', $bean->getFrom()->getTo());
     }
 }


### PR DESCRIPTION
If a foreign key points to a non primary key, the getters for the objets fail.

Adding failing test first.