### PR TITLE
Fix bean name in generated Dao

### DIFF
--- a/src/Utils/TDBMDaoGenerator.php
+++ b/src/Utils/TDBMDaoGenerator.php
@@ -211,9 +211,6 @@ class $className extends $baseClassName
 
         list($defaultSort, $defaultSortDirection) = $this->getDefaultSortColumnFromAnnotation($table);
 
-        // FIXME: lowercase tables with _ in the name should work!
-        $tableCamel = self::toSingular(self::toCamelCase($tableName));
-
         $beanClassWithoutNameSpace = $beanClassName;
         $beanClassName = $beannamespace.'\\'.$beanClassName;
 
@@ -286,7 +283,7 @@ class $baseClassName
     }
 
     /**
-     * Get all $tableCamel records.
+     * Get all $beanClassWithoutNameSpace records.
      *
      * @return {$beanClassWithoutNameSpace}[]|ResultIterator
      */


### PR DESCRIPTION
When generating abstract Dao class, PHPDoc for method `findAll` mentions a bean class that may differ from actual returned class.