### PR TITLE
Fixing issue with cascading save

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,7 +2,12 @@ build:
     environment:
         php:
             version: 7.1
-
+    nodes:
+        analysis:
+            project_setup:
+                override: true
+            tests:
+                override: [php-scrutinizer-run]
 checks:
     php:
         code_rating: true

--- a/src/DbRow.php
+++ b/src/DbRow.php
@@ -348,7 +348,7 @@ class DbRow
                     throw TDBMMissingReferenceException::referenceDeleted($this->dbTableName, $reference);
                 }
                 $foreignColumns = $fk->getUnquotedForeignColumns();
-                $refBeanValues = $firstRefDbRow->_getDbRow();
+                $refBeanValues = $firstRefDbRow->dbRow;
                 for ($i = 0, $count = count($localColumns); $i < $count; ++$i) {
                     $dbRow[$localColumns[$i]] = $refBeanValues[$foreignColumns[$i]];
                 }

--- a/src/TDBMService.php
+++ b/src/TDBMService.php
@@ -873,9 +873,7 @@ class TDBMService
     public function getPrimaryKeysForObjectFromDbRow(DbRow $dbRow)
     {
         $table = $dbRow->_getDbTableName();
-        //$dbRowData = $dbRow->_getDbRow();
 
-        //return $this->_getPrimaryKeysFromObjectData($table, $dbRowData);
         $primaryKeyColumns = $this->getPrimaryKeyColumns($table);
         $values = array();
         foreach ($primaryKeyColumns as $column) {

--- a/src/TDBMService.php
+++ b/src/TDBMService.php
@@ -873,9 +873,19 @@ class TDBMService
     public function getPrimaryKeysForObjectFromDbRow(DbRow $dbRow)
     {
         $table = $dbRow->_getDbTableName();
-        $dbRowData = $dbRow->_getDbRow();
+        //$dbRowData = $dbRow->_getDbRow();
 
-        return $this->_getPrimaryKeysFromObjectData($table, $dbRowData);
+        //return $this->_getPrimaryKeysFromObjectData($table, $dbRowData);
+        $primaryKeyColumns = $this->getPrimaryKeyColumns($table);
+        $values = array();
+        foreach ($primaryKeyColumns as $column) {
+            $value = $dbRow->get($column);
+            if ($value !== null) {
+                $values[$column] = $value;
+            }
+        }
+
+        return $values;
     }
 
     /**

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -1584,4 +1584,27 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
         $this->assertNotEmpty($article2->getId());
         $this->assertNotSame($article->getId(), $article2->getId());
     }
+
+    /**
+     * @depends testDaoGeneration
+     */
+    public function testRecursiveSave()
+    {
+        $categoryDao = new CategoryDao($this->tdbmService);
+
+        $root1 = new CategoryBean('Root1');
+        $categoryDao->save($root1);
+        // Root 2 is not saved yet.
+        $root2 = new CategoryBean('Root2');
+        $intermediate = new CategoryBean('Intermediate');
+        $categoryDao->save($intermediate);
+
+        // Let's switch the parent to a bean in detached state.
+        $intermediate->setParent($root2);
+
+        // Now, let's save a new category that references the leaf category.
+        $leaf = new CategoryBean('Leaf');
+        $leaf->setParent($intermediate);
+        $categoryDao->save($leaf);
+    }
 }


### PR DESCRIPTION
This fixes issues where a new bean is referencing an existing bean that has been modified to point itself to a new bean.

The calls to getDbRow where recursive and this was not necessary, wreaking havok down the line on beans that where not saved further down the hierarchy.