### PR TITLE
Exception message updated when no result found for primary key(s)

### DIFF
--- a/src/TDBMService.php
+++ b/src/TDBMService.php
@@ -1240,7 +1240,14 @@ class TDBMService
         }
 
         // Did not find the object in cache? Let's query it!
-        return $this->findObjectOrFail($table, $primaryKeys, [], $additionalTablesFetch, $className);
+        try {
+            return $this->findObjectOrFail($table, $primaryKeys, [], $additionalTablesFetch, $className);
+        } catch (NoBeanFoundException $exception) {
+            $primaryKeysStringified = implode(' and ', array_map(function($key, $value) {
+                return "'".$key."' = ".$value;
+            }, array_keys($primaryKeys), $primaryKeys));
+            throw new NoBeanFoundException("No result found for query on table '".$table."' for ".$primaryKeysStringified, 0, $exception);
+        }
     }
 
     /**

--- a/tests/TDBMServiceTest.php
+++ b/tests/TDBMServiceTest.php
@@ -617,6 +617,16 @@ SQL;
     }
 
     /**
+     * @throws NoBeanFoundException
+     */
+    public function testFindObjectByPkException()
+    {
+        $this->expectException(NoBeanFoundException::class);
+        $this->expectExceptionMessage("No result found for query on table 'contact' for 'id' = -42");
+        $bean = $this->tdbmService->findObjectByPk('contact', ['id' => -42], [], false, TDBMObject::class);
+    }
+
+    /**
      * @expectedException \TheCodingMachine\TDBM\DuplicateRowException
      *
      * @throws DuplicateRowException


### PR DESCRIPTION
The previous exception message only displayed the table name. Now, it will also display the value(s) of the primary key(s).

Ex:
`No result found for query on table 'members' for 'idmember' = 12`