### PR TITLE
Weakref issue: the garbage collector can be triggered between "has" and "get"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ before_script:
 - composer update --prefer-dist
 # For some reason, $PREFER_LOWEST will fail unless a composer update has been run before...
 - if [ "$PREFER_LOWEST" = "--prefer-lowest" ] ; then composer update --prefer-dist --prefer-lowest; fi
+- pecl install weakref-beta
 script:
 # Let's run the Oracle script only when the password is available (it is not available in forks unfortunately)
 - if [ "$DB" != "oracle" ] ; then ./vendor/bin/phpunit $PHPUNITFILE; else docker run -v $(pwd):/app -v $(pwd)/tests/Fixtures/oracle-startup.sql:/docker-entrypoint-initdb.d/oracle-startup.sql moufmouf/oracle-xe-php vendor/bin/phpunit $PHPUNITFILE; fi

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,5 @@
 parameters:
     ignoreErrors:
-     - "#Instantiated class WeakRef not found.#"
      - "#Method JsonSerializable::jsonSerialize\\(\\) invoked with 1 parameter, 0 required.#"
      - "#Method .*::.* should return .* but returns .*TheCodingMachine\\\\TDBM\\\\AbstractTDBMObject#"
      - "#Method .*::.* should return .* but returns TheCodingMachine\\\\TDBM\\\\ResultIterator#"

--- a/src/InnerResultIterator.php
+++ b/src/InnerResultIterator.php
@@ -225,8 +225,8 @@ class InnerResultIterator implements \Iterator, \Countable, \ArrayAccess
                 $primaryKeys = $this->tdbmService->_getPrimaryKeysFromObjectData($mainBeanTableName, $beanData[$mainBeanTableName]);
                 $hash = $this->tdbmService->getObjectHash($primaryKeys);
 
-                if ($this->objectStorage->has($mainBeanTableName, $hash)) {
-                    $dbRow = $this->objectStorage->get($mainBeanTableName, $hash);
+                $dbRow = $this->objectStorage->get($mainBeanTableName, $hash);
+                if ($dbRow !== null) {
                     $bean = $dbRow->getTDBMObject();
                 } else {
                     // Let's construct the bean

--- a/src/ObjectStorageInterface.php
+++ b/src/ObjectStorageInterface.php
@@ -21,15 +21,8 @@ interface ObjectStorageInterface
      */
     public function set(string $tableName, $id, DbRow $dbRow): void;
 
-    /**
-     * Checks if an object is in the storage.
-     *
-     * @param string $tableName
-     * @param string|int $id
-     *
-     * @return bool
-     */
-    public function has(string $tableName, $id): bool;
+    // Notice: the interface has no "has" method because it is meaningless in the case of the Weakref implementation.
+    // See https://github.com/thecodingmachine/tdbm/pull/80#issuecomment-385902994
 
     /**
      * Returns an object from the storage (or null if no object is set).

--- a/src/ObjectStorageInterface.php
+++ b/src/ObjectStorageInterface.php
@@ -41,11 +41,4 @@ interface ObjectStorageInterface
      * @param string|int $id
      */
     public function remove(string $tableName, $id): void;
-
-    /**
-     * Applies the callback to all objects.
-     *
-     * @param callable $callback
-     */
-    public function apply(callable $callback): void;
 }

--- a/src/StandardObjectStorage.php
+++ b/src/StandardObjectStorage.php
@@ -78,18 +78,4 @@ class StandardObjectStorage implements ObjectStorageInterface
     {
         unset($this->objects[$tableName][$id]);
     }
-
-    /**
-     * Applies the callback to all objects.
-     *
-     * @param callable $callback
-     */
-    public function apply(callable $callback): void
-    {
-        foreach ($this->objects as $tableName => $table) {
-            foreach ($table as $id => $obj) {
-                $callback($obj, $tableName, $id);
-            }
-        }
-    }
 }

--- a/src/StandardObjectStorage.php
+++ b/src/StandardObjectStorage.php
@@ -52,19 +52,6 @@ class StandardObjectStorage implements ObjectStorageInterface
     }
 
     /**
-     * Checks if an object is in the storage.
-     *
-     * @param string $tableName
-     * @param string|int $id
-     *
-     * @return bool
-     */
-    public function has(string $tableName, $id): bool
-    {
-        return isset($this->objects[$tableName][$id]);
-    }
-
-    /**
      * Returns an object from the storage (or null if no object is set).
      *
      * @param string $tableName

--- a/src/WeakrefObjectStorage.php
+++ b/src/WeakrefObjectStorage.php
@@ -93,25 +93,6 @@ class WeakrefObjectStorage implements ObjectStorageInterface
         unset($this->objects[$tableName][$id]);
     }
 
-    /**
-     * Applies the callback to all objects.
-     *
-     * @param callable $callback
-     */
-    public function apply(callable $callback): void
-    {
-        foreach ($this->objects as $tableName => $table) {
-            foreach ($table as $id => $ref) {
-                $obj = $ref->get();
-                if ($obj !== null) {
-                    $callback($obj, $tableName, $id);
-                } else {
-                    unset($this->objects[$tableName][$id]);
-                }
-            }
-        }
-    }
-
     private function cleanupDanglingWeakRefs(): void
     {
         foreach ($this->objects as $tableName => $table) {

--- a/tests/StandardObjectStorageTest.php
+++ b/tests/StandardObjectStorageTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace TheCodingMachine\TDBM;
+
+
+class StandardObjectStorageTest extends \PHPUnit_Framework_TestCase
+{
+    public function testObjectStorage()
+    {
+        $objectStorage = new StandardObjectStorage();
+        $this->assertNull($objectStorage->get('foo', 42));
+        $dbRow = $this->createMock(DbRow::class);
+        $objectStorage->set('foo', 42, $dbRow);
+        $this->assertSame($dbRow, $objectStorage->get('foo', 42));
+        $objectStorage->remove('foo', 42);
+        $this->assertNull($objectStorage->get('foo', 42));
+    }
+}

--- a/tests/WeakrefObjectStorageTest.php
+++ b/tests/WeakrefObjectStorageTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace TheCodingMachine\TDBM;
+
+
+class WeakrefObjectStorageTest extends \PHPUnit_Framework_TestCase
+{
+    public function testObjectStorage()
+    {
+        $objectStorage = new WeakrefObjectStorage();
+        $this->assertNull($objectStorage->get('foo', 42));
+        $dbRow = $this->createMock(DbRow::class);
+        $objectStorage->set('foo', 42, $dbRow);
+        $this->assertSame($dbRow, $objectStorage->get('foo', 42));
+        $objectStorage->remove('foo', 42);
+        $this->assertNull($objectStorage->get('foo', 42));
+    }
+
+    public function testDanglingPointers()
+    {
+        $objectStorage = new WeakrefObjectStorage();
+        $dbRow = $this->createMock(DbRow::class);
+
+        for ($i=0; $i<10001; $i++) {
+            $objectStorage->set('foo', $i, clone $dbRow);
+        }
+        $this->assertNull($objectStorage->get('foo', 42));
+    }
+}

--- a/tests/WeakrefObjectStorageTest.php
+++ b/tests/WeakrefObjectStorageTest.php
@@ -7,6 +7,10 @@ class WeakrefObjectStorageTest extends \PHPUnit_Framework_TestCase
 {
     public function testObjectStorage()
     {
+        if (!\class_exists(\WeakRef::class)) {
+            $this->markTestSkipped('No weakref extension detected');
+            return;
+        }
         $objectStorage = new WeakrefObjectStorage();
         $this->assertNull($objectStorage->get('foo', 42));
         $dbRow = $this->createMock(DbRow::class);
@@ -18,6 +22,10 @@ class WeakrefObjectStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testDanglingPointers()
     {
+        if (!\class_exists(\WeakRef::class)) {
+            $this->markTestSkipped('No weakref extension detected');
+            return;
+        }
         $objectStorage = new WeakrefObjectStorage();
         $dbRow = $this->createMock(DbRow::class);
 


### PR DESCRIPTION
See #80.

This PR solves the problem by removing the "has" method from the StorageInterface and removing all calls to $weakRef->valid() if they can be replaced by a $weakRef->get() + a check on a null return value.