### PR TITLE
Decimal type should be mapped to string

### DIFF
--- a/src/Utils/TDBMDaoGenerator.php
+++ b/src/Utils/TDBMDaoGenerator.php
@@ -659,7 +659,7 @@ class $daoFactoryClassName
             Type::DATETIMETZ_IMMUTABLE => '\DateTimeImmutable',
             Type::DATE_IMMUTABLE => '\DateTimeImmutable',
             Type::TIME_IMMUTABLE => '\DateTimeImmutable',
-            Type::DECIMAL => 'float',
+            Type::DECIMAL => 'string',
             Type::INTEGER => 'int',
             Type::OBJECT => 'string',
             Type::SMALLINT => 'int',

--- a/tests/TDBMAbstractServiceTest.php
+++ b/tests/TDBMAbstractServiceTest.php
@@ -299,6 +299,7 @@ abstract class TDBMAbstractServiceTest extends \PHPUnit_Framework_TestCase
             ->column('name')->string(255)
             ->column('anchorage_country')->references('country')->notNull()->then()
             ->column('current_country')->references('country')->null()->then()
+            ->column('length')->decimal(10, 2)->null()->then()
             ->unique(['anchorage_country', 'name']);
 
         $db->table('sailed_countries')

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -41,6 +41,7 @@ use TheCodingMachine\TDBM\Test\Dao\Bean\CategoryBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\CountryBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\DogBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\FileBean;
+use TheCodingMachine\TDBM\Test\Dao\Bean\Generated\BoatBaseBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\Generated\UserBaseBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\PersonBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\RefNoPrimKeyBean;
@@ -1697,5 +1698,11 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
 
         $this->assertCount(1, $users);
         $this->assertSame('John Doe', $users[0]->getName());
+    }
+
+    public function testDecimalIsMappedToString()
+    {
+        $reflectionClass = new \ReflectionClass(BoatBaseBean::class);
+        $this->assertSame('string', (string) $reflectionClass->getMethod('getLength')->getReturnType());
     }
 }


### PR DESCRIPTION
Decimal type is mapped by DBAL to string, so we should map it to string.
See #81