### PR TITLE
Save should update columns only if they are changed

### DIFF
--- a/src/AbstractTDBMObject.php
+++ b/src/AbstractTDBMObject.php
@@ -177,9 +177,11 @@ abstract class AbstractTDBMObject implements JsonSerializable
     {
         $this->status = $state;
 
-        // TODO: we might ignore the loaded => dirty state here! dirty status comes from the db_row itself.
-        foreach ($this->dbRows as $dbRow) {
-            $dbRow->_setStatus($state);
+        // The dirty state comes form the db_row itself so there is no need to set it from the called.
+        if ($state !== TDBMObjectStateEnum::STATE_DIRTY) {
+            foreach ($this->dbRows as $dbRow) {
+                $dbRow->_setStatus($state);
+            }
         }
 
         if ($state === TDBMObjectStateEnum::STATE_DELETED) {

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -1671,6 +1671,26 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
         $this->assertInternalType('resource', $resource);
         $firstLine = fgets($resource);
         $this->assertSame("<?php\n", $firstLine);
+
+        stream_get_contents($resource);
+
+        $loadedFile->setId($loadedFile->getId());
+
+        $fileDao->save($loadedFile);
+    }
+
+    /**
+     * @depends testReadBlob
+     */
+    public function testReadAndSaveBlob()
+    {
+        $fileDao = new FileDao($this->tdbmService);
+        $loadedFile = $fileDao->getById(1);
+
+        $resource = $loadedFile->getFile();
+
+        $firstLine = fgets($resource);
+        $this->assertSame("<?php\n", $firstLine);
     }
 
     /**


### PR DESCRIPTION
For beans that are updated on save, the database should receive only changed columns.

This will also improve performances by limiting the amount of data saved to database.

This PR fixes #89 