### PR TITLE
Fixing colliding cache key for the schema

### DIFF
--- a/src/TDBMSchemaAnalyzer.php
+++ b/src/TDBMSchemaAnalyzer.php
@@ -75,7 +75,7 @@ class TDBMSchemaAnalyzer
     public function getSchema(): Schema
     {
         if ($this->schema === null) {
-            $cacheKey = $this->getCachePrefix().'_schema';
+            $cacheKey = $this->getCachePrefix().'_immutable_schema';
             if ($this->cache->contains($cacheKey)) {
                 $this->schema = $this->cache->fetch($cacheKey);
             } else {


### PR DESCRIPTION
The TDBMSchemaAnalyzer and the SchemaAnalyzer were sharing a common cache key but they do not store the same thing in the cache key (one stores the schema and the other stores the schema with modified date column types switched to immutable)