### PR TITLE
fix pivot table + inheritance bean generation

### DIFF
--- a/tests/TDBMAbstractServiceTest.php
+++ b/tests/TDBMAbstractServiceTest.php
@@ -353,6 +353,11 @@ abstract class TDBMAbstractServiceTest extends \PHPUnit_Framework_TestCase
             ->column('name')->string(50)->then()
             ->primaryKey(['country_id', 'code']);
 
+        $db->table('contacts_countries')
+            ->column('id')->integer()->primaryKey()->autoIncrement()->comment('@Autoincrement')
+            ->column('contact_id')->references('contact')->notNull()
+            ->column('country_id')->references('country')->notNull();
+
         $sqlStmts = $toSchema->getMigrateFromSql($fromSchema, $connection->getDatabasePlatform());
 
         foreach ($sqlStmts as $sqlStmt) {


### PR DESCRIPTION
Quite a touchy one !

Lets imagine : you have a table A that extends table  B. Table B has en foreign key to table C, and table A has a pivot table relation (many to many) also to table C, then : 
```php
class B {
   getC() : C {...}
}

class A extends B {
   getC() : array {}
}
```

This situation throws the following error : 
```php
PHP Fatal error:  Declaration of B::getC(): C must be compatible with A::getC(): array in ...
```