### PR TITLE
Adding support for native WeakReferences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,10 @@ matrix:
       services:
         - postgresql
   allow_failures:
+    - php: 7.3 # 7.3 allowed to fail due to an issue with greenlion/PHP-SQL-Parser: https://github.com/greenlion/PHP-SQL-Parser/pull/304
+      env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
+    - php: 7.4
+      env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
     - php: 7.1
       env: PREFER_LOWEST="" DB=oracle PHPUNITFILE="-c phpunit.oracle.xml"
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,8 @@ matrix:
         - postgresql
     - php: 7.3
       env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
-    - php: "7.4snapshot"
-      env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
   allow_failures:
     - php: 7.3 # 7.3 allowed to fail due to an issue with greenlion/PHP-SQL-Parser: https://github.com/greenlion/PHP-SQL-Parser/pull/304
-    - php: "7.4snapshot"
     - php: 7.1
       env: PREFER_LOWEST="" DB=oracle PHPUNITFILE="-c phpunit.oracle.xml"
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,11 @@ matrix:
         - postgresql
     - php: 7.3
       env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
-    - php: nightly
+    - php: "7.4snapshot"
       env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
   allow_failures:
     - php: 7.3 # 7.3 allowed to fail due to an issue with greenlion/PHP-SQL-Parser: https://github.com/greenlion/PHP-SQL-Parser/pull/304
-    - php: nightly
+    - php: "7.4snapshot"
     - php: 7.1
       env: PREFER_LOWEST="" DB=oracle PHPUNITFILE="-c phpunit.oracle.xml"
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,12 @@ cache:
     - $HOME/.composer/cache
 matrix:
   include:
+    - php: 7.4
+      env: PREFER_LOWEST="" DB=mysql RUN_PHPSTAN=1 RUN_CSCHECK=1 RUN_REQUIRECHECKER=1 NO_WEAKREF=1
+      services:
+        - mysql
     - php: 7.2
-      env: PREFER_LOWEST="" DB=mysql RUN_PHPSTAN=1 RUN_CSCHECK=1 RUN_REQUIRECHECKER=1
+      env: PREFER_LOWEST="" DB=mysql
       services:
         - mysql
     - php: 7.3
@@ -57,11 +61,13 @@ matrix:
         postgresql: "9.6"
       services:
         - postgresql
+    - php: 7.3
+      env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
+    - php: nightly
+      env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
   allow_failures:
     - php: 7.3 # 7.3 allowed to fail due to an issue with greenlion/PHP-SQL-Parser: https://github.com/greenlion/PHP-SQL-Parser/pull/304
-      env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
-    - php: 7.4
-      env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
+    - php: nightly
     - php: 7.1
       env: PREFER_LOWEST="" DB=oracle PHPUNITFILE="-c phpunit.oracle.xml"
     - php: 7.1

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -3,7 +3,7 @@
     "null", "true", "false",
     "static", "self", "parent",
     "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object",
-    "WeakRef",
+    "WeakRef", "WeakReference",
     "TheCodingMachine\\TDBM\\Fixtures\\Interfaces\\TestUserDaoInterface",
     "TheCodingMachine\\TDBM\\Fixtures\\Traits\\TestUserDaoTrait",
     "TheCodingMachine\\TDBM\\Fixtures\\Interfaces\\TestUserInterface",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
      - "#expects array<string>, array<int, int|string> given.#"
      - "/Parameter #. \\$types of method Doctrine\\\\DBAL\\\\Connection::.*() expects array<int|string>, array<int, Doctrine\\\\DBAL\\\\Types\\\\Type> given./"
      - "#Method TheCodingMachine\\\\TDBM\\\\Schema\\\\ForeignKey::.*() should return .* but returns array<string>|string.#"
+     - '#Method TheCodingMachine\\TDBM\\NativeWeakrefObjectStorage::get\(\) should return TheCodingMachine\\TDBM\\DbRow\|null but returns object\|null.#'
      -
         message: '#Result of && is always false.#'
         path: src/Test/Dao/Bean/Generated/ArticleBaseBean.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,9 @@ parameters:
      - "#Method TheCodingMachine\\\\TDBM\\\\Schema\\\\ForeignKey::.*() should return .* but returns array<string>|string.#"
      - '#Method TheCodingMachine\\TDBM\\NativeWeakrefObjectStorage::get\(\) should return TheCodingMachine\\TDBM\\DbRow\|null but returns object\|null.#'
      -
+             message: '#WeakRef#'
+             path: src/WeakrefObjectStorage.php
+     -
         message: '#Result of && is always false.#'
         path: src/Test/Dao/Bean/Generated/ArticleBaseBean.php
     reportUnmatchedIgnoredErrors: false

--- a/src/NativeWeakrefObjectStorage.php
+++ b/src/NativeWeakrefObjectStorage.php
@@ -98,7 +98,7 @@ class NativeWeakrefObjectStorage implements ObjectStorageInterface
     {
         foreach ($this->objects as $tableName => $table) {
             foreach ($table as $id => $obj) {
-                if ($obj->valid() === false) {
+                if ($obj->get() === null) {
                     unset($this->objects[$tableName][$id]);
                 }
             }

--- a/src/NativeWeakrefObjectStorage.php
+++ b/src/NativeWeakrefObjectStorage.php
@@ -21,24 +21,23 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 namespace TheCodingMachine\TDBM;
 
+use WeakReference;
+
 /**
- * The WeakrefObjectStorage class is used to reference all beans that have been fetched from the database.
- * If a bean is requested twice from TDBM, the WeakrefObjectStorage is used to "cache" the bean.
- * Unlike the StandardObjectStorage, the WeakrefObjectStorage manages memory in a clever way, using the weakref
- * PHP extension. It is used if the "weakref" extension is available.
- * Otherwise, the StandardObjectStorage or NativeWeakrefObjectStorage (in PHP 7.4+) is used instead.
- *
- * Note: the weakref extension is available until PHP 7.2, but not available in PHP 7.3+
+ * The NativeWeakrefObjectStorage class is used to reference all beans that have been fetched from the database.
+ * If a bean is requested twice from TDBM, the NativeWeakrefObjectStorage is used to "cache" the bean.
+ * Unlike the StandardObjectStorage, the NativeWeakrefObjectStorage manages memory in a clever way, using WeakReference.
+ * WeakReference have been added in PHP 7.4.
  *
  * @author David Negrier
  */
-class WeakrefObjectStorage implements ObjectStorageInterface
+class NativeWeakrefObjectStorage implements ObjectStorageInterface
 {
     /**
      * An array of fetched object, accessible via table name and primary key.
      * If the primary key is split on several columns, access is done by an array of columns, serialized.
      *
-     * @var \WeakRef[][]
+     * @var WeakReference[][]
      */
     private $objects = array();
 
@@ -60,7 +59,7 @@ class WeakrefObjectStorage implements ObjectStorageInterface
      */
     public function set(string $tableName, $id, DbRow $dbRow): void
     {
-        $this->objects[$tableName][$id] = new \WeakRef($dbRow);
+        $this->objects[$tableName][$id] = WeakReference::create($dbRow);
         ++$this->garbageCollectorCount;
         if ($this->garbageCollectorCount === 10000) {
             $this->garbageCollectorCount = 0;

--- a/src/TDBMService.php
+++ b/src/TDBMService.php
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 namespace TheCodingMachine\TDBM;
 
+use function class_exists;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\ClearableCache;
 use Doctrine\Common\Cache\VoidCache;
@@ -46,7 +47,7 @@ use TheCodingMachine\TDBM\Utils\TDBMDaoGenerator;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Psr\Log\NullLogger;
-use function var_export;
+use WeakReference;
 
 /**
  * The TDBMService class is the main TDBM class. It provides methods to retrieve TDBMObject instances
@@ -179,7 +180,9 @@ class TDBMService
      */
     public function __construct(ConfigurationInterface $configuration)
     {
-        if (extension_loaded('weakref')) {
+        if (class_exists(WeakReference::class)) {
+            $this->objectStorage = new NativeWeakrefObjectStorage();
+        } elseif (extension_loaded('weakref')) {
             $this->objectStorage = new WeakrefObjectStorage();
         } else {
             $this->objectStorage = new StandardObjectStorage();

--- a/src/TDBMService.php
+++ b/src/TDBMService.php
@@ -102,7 +102,7 @@ class TDBMService
      * Access is done by table name and then by primary key.
      * If the primary key is split on several columns, access is done by an array of columns, serialized.
      *
-     * @var StandardObjectStorage|WeakrefObjectStorage
+     * @var ObjectStorageInterface
      */
     private $objectStorage;
 

--- a/tests/Commands/GenerateCommandTest.php
+++ b/tests/Commands/GenerateCommandTest.php
@@ -26,7 +26,7 @@ class GenerateCommandTest extends TDBMAbstractServiceTest
 
         $result = $this->callCommand(new GenerateCommand($this->getConfiguration()), $input);
 
-        $this->assertStringContainsString('Finished regenerating DAOs and beans', $result);
+        $this->assertContains('Finished regenerating DAOs and beans', $result);
     }
 
     /**

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -89,6 +89,7 @@ use TheCodingMachine\TDBM\Utils\PathFinder\NoPathFoundException;
 use TheCodingMachine\TDBM\Utils\PathFinder\PathFinder;
 use TheCodingMachine\TDBM\Utils\TDBMDaoGenerator;
 use Symfony\Component\Process\Process;
+use function gettype;
 
 class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
 {
@@ -1727,7 +1728,7 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
         $resource = $loadedFile->getFile();
         $result = fseek($resource, 0);
         $this->assertSame(0, $result);
-        $this->assertIsResource($resource);
+        $this->assertSame('resource', gettype($resource));
         $firstLine = fgets($resource);
         $this->assertSame("<?php\n", $firstLine);
     }
@@ -1741,7 +1742,7 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
         $loadedFile = $fileDao->getById(1);
 
         $resource = $loadedFile->getFile();
-        $this->assertIsResource($resource);
+        $this->assertSame('resource', gettype($resource));
         $firstLine = fgets($resource);
         $this->assertSame("<?php\n", $firstLine);
 

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -30,6 +30,7 @@ use Mouf\Database\SchemaAnalyzer\SchemaAnalyzer;
 use Ramsey\Uuid\Uuid;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionNamedType;
 use TheCodingMachine\TDBM\Dao\TestAlbumDao;
 use TheCodingMachine\TDBM\Dao\TestArticleDao;
 use TheCodingMachine\TDBM\Dao\TestCountryDao;
@@ -1611,9 +1612,10 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
     public function testTypeHintedConstructors(): void
     {
         $userBaseBeanReflectionConstructor = new \ReflectionMethod(UserBaseBean::class, '__construct');
+        /** @var ReflectionNamedType $nameParam */
         $nameParam = $userBaseBeanReflectionConstructor->getParameters()[0];
 
-        $this->assertSame('string', (string)$nameParam->getType());
+        $this->assertSame('string', $nameParam->getType()->getName());
     }
 
     /**
@@ -1826,7 +1828,7 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
     public function testDecimalIsMappedToString(): void
     {
         $reflectionClass = new \ReflectionClass(BoatBaseBean::class);
-        $this->assertSame('string', (string) $reflectionClass->getMethod('getLength')->getReturnType());
+        $this->assertSame('string', $reflectionClass->getMethod('getLength')->getReturnType()->getName());
     }
 
     /**


### PR DESCRIPTION
PHP 7.4 adds native support for WeakReferences.
There will be no need for the weakref extension (that was incompatible with PHP 7.3).

This PR adds support for these new Weakrefences.