### PR TITLE
Adding @ProtectedGetter and @ProtectedSetter annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New features:
 - \#95: Table and column annotations are now parsed using doctrine/annotations lexer/parser
 - \#97: Generated DAOs and beans are now purged automatically. When a table is removed, the matching generated beans and daos will be removed too.
 - \#116: New CodeGeneratorListernerInterface allows third party library to alter generated beans and DAOs on the fly (for the power users!)
+- \#125: New @ProtectedGetter, @ProtectedSetter and @ProtectedOneToMany annotations (to be used in the DB column comments) enable generating beans with protected getters and setters
 
 5.0
 ===

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New features:
 - \#96: New @Bean annotation in table comments to alter the name of a bean
 - \#95: Table and column annotations are now parsed using doctrine/annotations lexer/parser
 - \#97: Generated DAOs and beans are now purged automatically. When a table is removed, the matching generated beans and daos will be removed too.
-- \#116: New CodeGeneratorListernerInterface allows third party library to alter generated beans and DAOs on the fly (for the power users!)
+- \#116: New CodeGeneratorListenerInterface allows third party library to alter generated beans and DAOs on the fly (for the power users!)
 - \#125: New @ProtectedGetter, @ProtectedSetter and @ProtectedOneToMany annotations (to be used in the DB column comments) enable generating beans with protected getters and setters
 
 5.0

--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -169,3 +169,12 @@ Notice: a complete implementation should also check if a password needs rehashin
 
 <div class="alert alert-info">When you use the `@ProtectedGetter` annotation, TDBM will assume the column
 access is sensitive and will therefore prevent the column from being JSON serialized.</div>
+
+The @ProtectedOneToMany annotation
+----------------------------------
+<small>(Available in TDBM 5.1+)</small>
+
+This annotation can be put on a column comment to alter the visibility of the "inverse" relationship.
+
+For instance, if you put the `@ProtectedOneToMany` on the "country_id" column of a "users" table,
+then in the `Country` bean, the `getUsers()` method will be protected.

--- a/src/Utils/Annotation/AnnotationParser.php
+++ b/src/Utils/Annotation/AnnotationParser.php
@@ -42,6 +42,7 @@ class AnnotationParser
             'Bean' => Bean::class,
             'ProtectedGetter' => ProtectedGetter::class,
             'ProtectedSetter' => ProtectedSetter::class,
+            'ProtectedOneToMany' => ProtectedOneToMany::class,
         ];
         $annotations = $defaultAnnotations + $additionalAnnotations;
         return new self($annotations);

--- a/src/Utils/Annotation/AnnotationParser.php
+++ b/src/Utils/Annotation/AnnotationParser.php
@@ -39,7 +39,9 @@ class AnnotationParser
         $defaultAnnotations = [
             'UUID' => UUID::class,
             'Autoincrement' => Autoincrement::class,
-            'Bean' => Bean::class
+            'Bean' => Bean::class,
+            'ProtectedGetter' => ProtectedGetter::class,
+            'ProtectedSetter' => ProtectedSetter::class,
         ];
         $annotations = $defaultAnnotations + $additionalAnnotations;
         return new self($annotations);

--- a/src/Utils/Annotation/ProtectedGetter.php
+++ b/src/Utils/Annotation/ProtectedGetter.php
@@ -1,0 +1,14 @@
+<?php
+namespace TheCodingMachine\TDBM\Utils\Annotation;
+
+/**
+ * Makes the getter of the column protected.
+ *
+ * This annotation can only be used in a database column comment.
+ * When used, the column will also be removed from the default JSONSerialize
+ *
+ * @Annotation
+ */
+final class ProtectedGetter
+{
+}

--- a/src/Utils/Annotation/ProtectedOneToMany.php
+++ b/src/Utils/Annotation/ProtectedOneToMany.php
@@ -1,0 +1,16 @@
+<?php
+namespace TheCodingMachine\TDBM\Utils\Annotation;
+
+/**
+ * Makes the inverse relationship of a foreign key protected.
+ *
+ * For instance, if this annotation is put on a column users.country_id,
+ * the getUsers method of the Country bean will be protected.
+ *
+ * This annotation can only be used in a database column comment.
+ *
+ * @Annotation
+ */
+final class ProtectedOneToMany
+{
+}

--- a/src/Utils/Annotation/ProtectedSetter.php
+++ b/src/Utils/Annotation/ProtectedSetter.php
@@ -1,0 +1,13 @@
+<?php
+namespace TheCodingMachine\TDBM\Utils\Annotation;
+
+/**
+ * Makes the setter of the column protected.
+ *
+ * This annotation can only be used in a database column comment.
+ *
+ * @Annotation
+ */
+final class ProtectedSetter
+{
+}

--- a/src/Utils/BeanDescriptor.php
+++ b/src/Utils/BeanDescriptor.php
@@ -258,7 +258,7 @@ class BeanDescriptor implements BeanDescriptorInterface
                     continue;
                 }
 
-                $beanPropertyDescriptors[] = new ObjectBeanPropertyDescriptor($table, $fk, $this->namingStrategy, $this->beanNamespace);
+                $beanPropertyDescriptors[] = new ObjectBeanPropertyDescriptor($table, $fk, $this->namingStrategy, $this->beanNamespace, $this->annotationParser);
             } else {
                 $beanPropertyDescriptors[] = new ScalarBeanPropertyDescriptor($table, $column, $this->namingStrategy, $this->annotationParser);
             }
@@ -1053,7 +1053,7 @@ You should not put an alias on the main table name. So your \$from variable shou
             $fk = $this->isPartOfForeignKey($this->table, $this->table->getColumn($column));
             if ($fk !== null) {
                 if (!in_array($fk, $elements)) {
-                    $elements[] = new ObjectBeanPropertyDescriptor($this->table, $fk, $this->namingStrategy, $this->beanNamespace);
+                    $elements[] = new ObjectBeanPropertyDescriptor($this->table, $fk, $this->namingStrategy, $this->beanNamespace, $this->annotationParser);
                 }
             } else {
                 $elements[] = new ScalarBeanPropertyDescriptor($this->table, $this->table->getColumn($column), $this->namingStrategy, $this->annotationParser);

--- a/src/Utils/BeanDescriptor.php
+++ b/src/Utils/BeanDescriptor.php
@@ -348,7 +348,7 @@ class BeanDescriptor implements BeanDescriptorInterface
         $descriptors = [];
 
         foreach ($fks as $fk) {
-            $descriptors[] = new DirectForeignKeyMethodDescriptor($fk, $this->table, $this->namingStrategy);
+            $descriptors[] = new DirectForeignKeyMethodDescriptor($fk, $this->table, $this->namingStrategy, $this->annotationParser);
         }
 
         return $descriptors;

--- a/src/Utils/ForeignKeyAnalyzerTrait.php
+++ b/src/Utils/ForeignKeyAnalyzerTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace TheCodingMachine\TDBM\Utils;
+
+
+use Doctrine\DBAL\Schema\Column;
+use TheCodingMachine\TDBM\Utils\Annotation\Annotations;
+
+trait ForeignKeyAnalyzerTrait
+{
+    /**
+     * @var Annotations[]
+     */
+    private $annotations;
+    /**
+     * @var Column[]
+     */
+    private $localColumns;
+
+    /**
+     * @return Column[]
+     */
+    private function getLocalColumns(): array
+    {
+        if ($this->localColumns === null) {
+            $localColumnNames = $this->foreignKey->getUnquotedLocalColumns();
+
+            $this->localColumns = array_map([$this->foreignKey->getLocalTable(), 'getColumn'], $localColumnNames);
+        }
+        return $this->localColumns;
+    }
+
+    /**
+     * @return Annotations[]
+     */
+    private function getAnnotations(): array
+    {
+        if ($this->annotations === null) {
+            $this->annotations = [];
+
+            // Are all columns nullable?
+            foreach ($this->getLocalColumns() as $column) {
+                $this->annotations[] = $this->annotationParser->getColumnAnnotations($column, $this->foreignKey->getLocalTable());
+            }
+        }
+        return $this->annotations;
+    }
+}

--- a/src/Utils/ObjectBeanPropertyDescriptor.php
+++ b/src/Utils/ObjectBeanPropertyDescriptor.php
@@ -3,13 +3,14 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\TDBM\Utils;
 
+use function array_map;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
-use Mouf\Database\SchemaAnalyzer\SchemaAnalyzer;
 use TheCodingMachine\TDBM\TDBMException;
-use Zend\Code\Generator\DocBlock\Tag\ParamTag;
-use Zend\Code\Generator\DocBlock\Tag\ReturnTag;
+use TheCodingMachine\TDBM\Utils\Annotation\AnnotationParser;
+use TheCodingMachine\TDBM\Utils\Annotation\Annotations;
+use Zend\Code\Generator\AbstractMemberGenerator;
 use Zend\Code\Generator\MethodGenerator;
 use Zend\Code\Generator\ParameterGenerator;
 
@@ -28,16 +29,30 @@ class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
     private $beanNamespace;
 
     /**
+     * @var Annotations[]
+     */
+    private $annotations;
+    /**
+     * @var Column[]
+     */
+    private $localColumns;
+    /**
+     * @var AnnotationParser
+     */
+    private $annotationParser;
+
+    /**
      * ObjectBeanPropertyDescriptor constructor.
      * @param Table $table
      * @param ForeignKeyConstraint $foreignKey
      * @param NamingStrategyInterface $namingStrategy
      */
-    public function __construct(Table $table, ForeignKeyConstraint $foreignKey, NamingStrategyInterface $namingStrategy, string $beanNamespace)
+    public function __construct(Table $table, ForeignKeyConstraint $foreignKey, NamingStrategyInterface $namingStrategy, string $beanNamespace, AnnotationParser $annotationParser)
     {
         parent::__construct($table, $namingStrategy);
         $this->foreignKey = $foreignKey;
         $this->beanNamespace = $beanNamespace;
+        $this->annotationParser = $annotationParser;
     }
 
     /**
@@ -78,16 +93,26 @@ class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
     public function isCompulsory(): bool
     {
         // Are all columns nullable?
-        $localColumnNames = $this->foreignKey->getUnquotedLocalColumns();
-
-        foreach ($localColumnNames as $name) {
-            $column = $this->table->getColumn($name);
+        foreach ($this->getLocalColumns() as $column) {
             if ($column->getNotnull()) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * @return Column[]
+     */
+    private function getLocalColumns(): array
+    {
+        if ($this->localColumns === null) {
+            $localColumnNames = $this->foreignKey->getUnquotedLocalColumns();
+
+            $this->localColumns = array_map([$this->table, 'getColumn'], $localColumnNames);
+        }
+        return $this->localColumns;
     }
 
     /**
@@ -155,6 +180,10 @@ class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
 
         $getter->setBody('return $this->getRef('.var_export($this->foreignKey->getName(), true).', '.var_export($tableName, true).');');
 
+        if ($this->isGetterProtected()) {
+            $getter->setVisibility(AbstractMemberGenerator::VISIBILITY_PROTECTED);
+        }
+
         $setter = new MethodGenerator($setterName);
         $setter->setDocBlock('The setter for the '.$referencedBeanName.' object bound to this object via the '.implode(' and ', $this->foreignKey->getUnquotedLocalColumns()).' column.');
 
@@ -163,6 +192,10 @@ class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
         $setter->setReturnType('void');
 
         $setter->setBody('$this->setRef('.var_export($this->foreignKey->getName(), true).', $object, '.var_export($tableName, true).');');
+
+        if ($this->isSetterProtected()) {
+            $setter->setVisibility(AbstractMemberGenerator::VISIBILITY_PROTECTED);
+        }
 
         return [$getter, $setter];
     }
@@ -174,6 +207,10 @@ class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
      */
     public function getJsonSerializeCode(): string
     {
+        if ($this->isGetterProtected()) {
+            return '';
+        }
+
         if (!$this->isCompulsory()) {
             return 'if (!$stopRecursion) {
     $object = $this->'.$this->getGetterName().'();
@@ -205,5 +242,41 @@ class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
     public function isTypeHintable() : bool
     {
         return true;
+    }
+
+    private function isGetterProtected(): bool
+    {
+        foreach ($this->getAnnotations() as $annotations) {
+            if ($annotations->findAnnotation(Annotation\ProtectedGetter::class)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function isSetterProtected(): bool
+    {
+        foreach ($this->getAnnotations() as $annotations) {
+            if ($annotations->findAnnotation(Annotation\ProtectedSetter::class)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return Annotations[]
+     */
+    private function getAnnotations(): array
+    {
+        if ($this->annotations === null) {
+            $this->annotations = [];
+
+            // Are all columns nullable?
+            foreach ($this->getLocalColumns() as $column) {
+                $this->annotations[] = $this->annotationParser->getColumnAnnotations($column, $this->table);
+            }
+        }
+        return $this->annotations;
     }
 }

--- a/src/Utils/ObjectBeanPropertyDescriptor.php
+++ b/src/Utils/ObjectBeanPropertyDescriptor.php
@@ -19,6 +19,8 @@ use Zend\Code\Generator\ParameterGenerator;
  */
 class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
 {
+    use ForeignKeyAnalyzerTrait;
+
     /**
      * @var ForeignKeyConstraint
      */
@@ -28,14 +30,6 @@ class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
      */
     private $beanNamespace;
 
-    /**
-     * @var Annotations[]
-     */
-    private $annotations;
-    /**
-     * @var Column[]
-     */
-    private $localColumns;
     /**
      * @var AnnotationParser
      */
@@ -100,19 +94,6 @@ class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
         }
 
         return false;
-    }
-
-    /**
-     * @return Column[]
-     */
-    private function getLocalColumns(): array
-    {
-        if ($this->localColumns === null) {
-            $localColumnNames = $this->foreignKey->getUnquotedLocalColumns();
-
-            $this->localColumns = array_map([$this->table, 'getColumn'], $localColumnNames);
-        }
-        return $this->localColumns;
     }
 
     /**
@@ -264,19 +245,4 @@ class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
         return false;
     }
 
-    /**
-     * @return Annotations[]
-     */
-    private function getAnnotations(): array
-    {
-        if ($this->annotations === null) {
-            $this->annotations = [];
-
-            // Are all columns nullable?
-            foreach ($this->getLocalColumns() as $column) {
-                $this->annotations[] = $this->annotationParser->getColumnAnnotations($column, $this->table);
-            }
-        }
-        return $this->annotations;
-    }
 }

--- a/tests/TDBMAbstractServiceTest.php
+++ b/tests/TDBMAbstractServiceTest.php
@@ -332,7 +332,7 @@ abstract class TDBMAbstractServiceTest extends TestCase
             ->column('id')->integer()->primaryKey()->autoIncrement()->comment('@Autoincrement')
             ->column('file')->blob()
             ->column('md5')->string()->null()->comment("@ProtectedGetter\n@ProtectedSetter")
-            ->column('article_id')->references('article')->null()->comment("@ProtectedGetter\n@ProtectedSetter");
+            ->column('article_id')->references('article')->null()->comment("@ProtectedGetter\n@ProtectedSetter\n@ProtectedOneToMany");
 
         $toSchema->getTable('users')
             ->addUniqueIndex([$connection->quoteIdentifier('login')], 'users_login_idx')

--- a/tests/TDBMAbstractServiceTest.php
+++ b/tests/TDBMAbstractServiceTest.php
@@ -330,7 +330,9 @@ abstract class TDBMAbstractServiceTest extends TestCase
 
         $db->table('files')
             ->column('id')->integer()->primaryKey()->autoIncrement()->comment('@Autoincrement')
-            ->column('file')->blob();
+            ->column('file')->blob()
+            ->column('md5')->string()->null()->comment("@ProtectedGetter\n@ProtectedSetter")
+            ->column('article_id')->references('article')->null()->comment("@ProtectedGetter\n@ProtectedSetter");
 
         $toSchema->getTable('users')
             ->addUniqueIndex([$connection->quoteIdentifier('login')], 'users_login_idx')

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -43,6 +43,7 @@ use TheCodingMachine\TDBM\Test\Dao\Bean\CategoryBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\CountryBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\DogBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\FileBean;
+use TheCodingMachine\TDBM\Test\Dao\Bean\Generated\ArticleBaseBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\Generated\BoatBaseBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\Generated\FileBaseBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\Generated\UserBaseBean;
@@ -1725,6 +1726,9 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
 
         $this->assertTrue($md5Getter2->isProtected());
         $this->assertTrue($md5Setter2->isProtected());
+
+        $oneToManyGetter = new ReflectionMethod(ArticleBaseBean::class, 'getFiles');
+        $this->assertTrue($oneToManyGetter->isProtected());
 
         $fileDao = new FileDao($this->tdbmService);
         $loadedFile = $fileDao->getById(1);

--- a/tests/Utils/DirectForeignKeyMethodDescriptorTest.php
+++ b/tests/Utils/DirectForeignKeyMethodDescriptorTest.php
@@ -6,6 +6,7 @@ namespace TheCodingMachine\TDBM\Utils;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use PHPUnit\Framework\TestCase;
+use TheCodingMachine\TDBM\Utils\Annotation\AnnotationParser;
 
 class DirectForeignKeyMethodDescriptorTest extends TestCase
 {
@@ -14,7 +15,8 @@ class DirectForeignKeyMethodDescriptorTest extends TestCase
         $fk = $this->createMock(ForeignKeyConstraint::class);
         $table = $this->createMock(Table::class);
         $ns = $this->createMock(DefaultNamingStrategy::class);
-        $descriptor = new DirectForeignKeyMethodDescriptor($fk, $table, $ns);
+        $ap = $this->createMock(AnnotationParser::class);
+        $descriptor = new DirectForeignKeyMethodDescriptor($fk, $table, $ns, $ap);
 
         $this->assertSame($fk, $descriptor->getForeignKey());
         $this->assertSame($table, $descriptor->getMainTable());


### PR DESCRIPTION
This PR adds the ability to make generated getters and setters protected instead of public using annotations in the DB column.

This enables to develop non-anemic beans.