### PR TITLE
Generate our own FK names and cache to avoid conflict on generated files

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
      - "#should return array<TheCodingMachine\\\\TDBM\\\\AbstractTDBMObject> but returns array<int, object>#"
      - "#expects array<string>, array<int, int|string> given.#"
      - "/Parameter #. \\$types of method Doctrine\\\\DBAL\\\\Connection::.*() expects array<int|string>, array<int, Doctrine\\\\DBAL\\\\Types\\\\Type> given./"
+     - "#Method TheCodingMachine\\\\TDBM\\\\Schema\\\\ForeignKey::.*() should return .* but returns array<string>|string.#"
     reportUnmatchedIgnoredErrors: false
 includes:
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/AbstractTDBMObject.php
+++ b/src/AbstractTDBMObject.php
@@ -22,6 +22,7 @@ namespace TheCodingMachine\TDBM;
  */
 
 use JsonSerializable;
+use TheCodingMachine\TDBM\Schema\ForeignKeys;
 
 /**
  * Instances of this class represent a "bean". Usually, a bean is mapped to a row of one table.
@@ -90,7 +91,7 @@ abstract class AbstractTDBMObject implements JsonSerializable
     {
         // FIXME: lazy loading should be forbidden on tables with inheritance and dynamic type assignation...
         if (!empty($tableName)) {
-            $this->dbRows[$tableName] = new DbRow($this, $tableName, $primaryKeys, $tdbmService);
+            $this->dbRows[$tableName] = new DbRow($this, $tableName, static::getForeignKeys($tableName), $primaryKeys, $tdbmService);
         }
 
         if ($tdbmService === null) {
@@ -116,7 +117,7 @@ abstract class AbstractTDBMObject implements JsonSerializable
         $this->tdbmService = $tdbmService;
 
         foreach ($beanData as $table => $columns) {
-            $this->dbRows[$table] = new DbRow($this, $table, $tdbmService->_getPrimaryKeysFromObjectData($table, $columns), $tdbmService, $columns);
+            $this->dbRows[$table] = new DbRow($this, $table, static::getForeignKeys($table), $tdbmService->_getPrimaryKeysFromObjectData($table, $columns), $tdbmService, $columns);
         }
 
         $this->status = TDBMObjectStateEnum::STATE_LOADED;
@@ -133,7 +134,7 @@ abstract class AbstractTDBMObject implements JsonSerializable
     {
         $this->tdbmService = $tdbmService;
 
-        $this->dbRows[$tableName] = new DbRow($this, $tableName, $primaryKeys, $tdbmService);
+        $this->dbRows[$tableName] = new DbRow($this, $tableName, static::getForeignKeys($tableName), $primaryKeys, $tdbmService);
 
         $this->status = TDBMObjectStateEnum::STATE_NOT_LOADED;
     }
@@ -512,13 +513,12 @@ abstract class AbstractTDBMObject implements JsonSerializable
      *
      * @param string $tableName
      * @param string $foreignKeyName
-     * @param string $searchTableName
      * @param mixed[] $searchFilter
      * @param string $orderString     The ORDER BY part of the query. All columns must be prefixed by the table name (in the form: table.column). WARNING : This parameter is not kept when there is an additionnal or removal object !
      *
      * @return AlterableResultIterator
      */
-    protected function retrieveManyToOneRelationshipsStorage(string $tableName, string $foreignKeyName, string $searchTableName, array $searchFilter, string $orderString = null) : AlterableResultIterator
+    protected function retrieveManyToOneRelationshipsStorage(string $tableName, string $foreignKeyName, array $searchFilter, string $orderString = null) : AlterableResultIterator
     {
         $key = $tableName.'___'.$foreignKeyName;
         $alterableResultIterator = $this->getManyToOneAlterableResultIterator($tableName, $foreignKeyName);
@@ -526,7 +526,7 @@ abstract class AbstractTDBMObject implements JsonSerializable
             return $alterableResultIterator;
         }
 
-        $unalteredResultIterator = $this->tdbmService->findObjects($searchTableName, $searchFilter, [], $orderString);
+        $unalteredResultIterator = $this->tdbmService->findObjects($tableName, $searchFilter, [], $orderString);
 
         $alterableResultIterator->setResultIterator($unalteredResultIterator->getIterator());
 
@@ -620,9 +620,9 @@ abstract class AbstractTDBMObject implements JsonSerializable
 
     private function registerTable(string $tableName): void
     {
-        $dbRow = new DbRow($this, $tableName);
+        $dbRow = new DbRow($this, $tableName, static::getForeignKeys($tableName));
 
-        if (in_array($this->status, [TDBMObjectStateEnum::STATE_NOT_LOADED, TDBMObjectStateEnum::STATE_LOADED, TDBMObjectStateEnum::STATE_DIRTY])) {
+        if (in_array($this->status, [TDBMObjectStateEnum::STATE_NOT_LOADED, TDBMObjectStateEnum::STATE_LOADED, TDBMObjectStateEnum::STATE_DIRTY], true)) {
             // Let's get the primary key for the new table
             $anotherDbRow = array_values($this->dbRows)[0];
             /* @var $anotherDbRow DbRow */
@@ -663,5 +663,13 @@ abstract class AbstractTDBMObject implements JsonSerializable
      */
     protected function onDelete() : void
     {
+    }
+
+    /**
+     * Returns the foreign keys used by this bean.
+     */
+    protected static function getForeignKeys(string $tableName): ForeignKeys
+    {
+        return new ForeignKeys([]);
     }
 }

--- a/src/DbRow.php
+++ b/src/DbRow.php
@@ -21,6 +21,8 @@ namespace TheCodingMachine\TDBM;
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+use TheCodingMachine\TDBM\Schema\ForeignKeys;
+
 /**
  * Instances of this class represent a row in a database.
  *
@@ -94,6 +96,10 @@ class DbRow
      * @var array
      */
     private $modifiedReferences = [];
+    /**
+     * @var ForeignKeys
+     */
+    private $foreignKeys;
 
     /**
      * You should never call the constructor directly. Instead, you should use the
@@ -109,10 +115,11 @@ class DbRow
      * @param mixed[] $dbRow
      * @throws TDBMException
      */
-    public function __construct(AbstractTDBMObject $object, string $tableName, array $primaryKeys = array(), TDBMService $tdbmService = null, array $dbRow = [])
+    public function __construct(AbstractTDBMObject $object, string $tableName, ForeignKeys $foreignKeys, array $primaryKeys = array(), TDBMService $tdbmService = null, array $dbRow = [])
     {
         $this->object = $object;
         $this->dbTableName = $tableName;
+        $this->foreignKeys = $foreignKeys;
 
         $this->status = TDBMObjectStateEnum::STATE_DETACHED;
 
@@ -277,7 +284,7 @@ class DbRow
             $this->_dbLoadIfNotLoaded();
 
             // Let's match the name of the columns to the primary key values
-            $fk = $this->tdbmService->_getForeignKeyByName($this->dbTableName, $foreignKeyName);
+            $fk = $this->foreignKeys->getForeignKey($foreignKeyName);
 
             $values = [];
             foreach ($fk->getUnquotedLocalColumns() as $column) {
@@ -388,7 +395,7 @@ class DbRow
         // Let's merge $dbRow and $references
         foreach ($references as $foreignKeyName => $reference) {
             // Let's match the name of the columns to the primary key values
-            $fk = $this->tdbmService->_getForeignKeyByName($this->dbTableName, $foreignKeyName);
+            $fk = $this->foreignKeys->getForeignKey($foreignKeyName);
             $localColumns = $fk->getUnquotedLocalColumns();
 
             if ($reference !== null) {

--- a/src/Schema/ForeignKey.php
+++ b/src/Schema/ForeignKey.php
@@ -1,0 +1,62 @@
+<?php
+
+
+namespace TheCodingMachine\TDBM\Schema;
+
+
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+
+class ForeignKey
+{
+    public const FOREIGN_TABLE = 'foreignTable';
+    public const LOCAL_COLUMNS = 'localColumns';
+    public const FOREIGN_COLUMNS = 'foreignColumns';
+
+    /**
+     * @var array<string, string|array<string>>
+     */
+    private $foreignKey;
+
+    /**
+     * @param array<string, string|array<string>> $foreignKey
+     */
+    public function __construct(array $foreignKey)
+    {
+        $this->foreignKey = $foreignKey;
+    }
+
+    public static function createFromFk(ForeignKeyConstraint $fk): self
+    {
+        return new self([
+            self::FOREIGN_TABLE => $fk->getForeignTableName(),
+            self::LOCAL_COLUMNS => $fk->getUnquotedLocalColumns(),
+            self::FOREIGN_COLUMNS => $fk->getUnquotedForeignColumns(),
+        ]);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getUnquotedLocalColumns(): array
+    {
+        return $this->foreignKey[self::LOCAL_COLUMNS];
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getUnquotedForeignColumns(): array
+    {
+        return $this->foreignKey[self::FOREIGN_COLUMNS];
+    }
+
+    public function getForeignTableName(): string
+    {
+        return $this->foreignKey[self::FOREIGN_TABLE];
+    }
+
+    public function getCacheKey(): string
+    {
+        return 'from__'.implode(',', $this->getUnquotedLocalColumns()) . '__to__table__' . $this->getForeignTableName() . '__columns__' . implode(',', $this->getUnquotedForeignColumns());
+    }
+}

--- a/src/Schema/ForeignKeys.php
+++ b/src/Schema/ForeignKeys.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace TheCodingMachine\TDBM\Schema;
+
+
+class ForeignKeys
+{
+    /**
+     * @var array
+     */
+    private $foreignKeys;
+
+    /**
+     * @var array
+     */
+    private $foreignKey;
+
+    /**
+     * @param array<string, array<string, string|array<string>>> $foreignKeys
+     */
+    public function __construct(array $foreignKeys)
+    {
+        $this->foreignKeys = $foreignKeys;
+        $this->foreignKey = [];
+    }
+
+    public function getForeignKey(string $fkName): ForeignKey
+    {
+        if (!isset($this->foreignKey[$fkName])) {
+            $this->foreignKey[$fkName] = new ForeignKey($this->foreignKeys[$fkName]);
+        }
+        return $this->foreignKey[$fkName];
+    }
+
+}

--- a/src/TDBMService.php
+++ b/src/TDBMService.php
@@ -1424,19 +1424,6 @@ class TDBMService
     }
 
     /**
-     * Returns the foreign key object.
-     *
-     * @param string $table
-     * @param string $fkName
-     *
-     * @return ForeignKeyConstraint
-     */
-    public function _getForeignKeyByName(string $table, string $fkName): ForeignKeyConstraint
-    {
-        return $this->tdbmSchemaAnalyzer->getSchema()->getTable($table)->getForeignKey($fkName);
-    }
-
-    /**
      * @param string $pivotTableName
      * @param AbstractTDBMObject $bean
      *

--- a/src/Utils/DirectForeignKeyMethodDescriptor.php
+++ b/src/Utils/DirectForeignKeyMethodDescriptor.php
@@ -7,6 +7,7 @@ namespace TheCodingMachine\TDBM\Utils;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use TheCodingMachine\TDBM\AlterableResultIterator;
+use TheCodingMachine\TDBM\Schema\ForeignKey;
 use TheCodingMachine\TDBM\TDBMException;
 use TheCodingMachine\TDBM\Utils\Annotation\AnnotationParser;
 use Zend\Code\Generator\AbstractMemberGenerator;
@@ -107,11 +108,12 @@ class DirectForeignKeyMethodDescriptor implements MethodDescriptorInterface
         ]));
         $getter->setReturnType(AlterableResultIterator::class);
 
+        $tdbmFk = ForeignKey::createFromFk($this->foreignKey);
+
         $code = sprintf(
-            'return $this->retrieveManyToOneRelationshipsStorage(%s, %s, %s, %s);',
+            'return $this->retrieveManyToOneRelationshipsStorage(%s, %s, %s);',
             var_export($this->foreignKey->getLocalTableName(), true),
-            var_export($this->foreignKey->getName(), true),
-            var_export($this->foreignKey->getLocalTableName(), true),
+            var_export($tdbmFk->getCacheKey(), true),
             $this->getFilters($this->foreignKey)
         );
 

--- a/src/Utils/ObjectBeanPropertyDescriptor.php
+++ b/src/Utils/ObjectBeanPropertyDescriptor.php
@@ -7,6 +7,7 @@ use function array_map;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use TheCodingMachine\TDBM\Schema\ForeignKey;
 use TheCodingMachine\TDBM\TDBMException;
 use TheCodingMachine\TDBM\Utils\Annotation\AnnotationParser;
 use TheCodingMachine\TDBM\Utils\Annotation\Annotations;
@@ -158,8 +159,9 @@ class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
         $getter->getDocBlock()->setTag(new ReturnTag($types));*/
 
         $getter->setReturnType(($isNullable?'?':'').$this->beanNamespace.'\\'.$referencedBeanName);
+        $tdbmFk = ForeignKey::createFromFk($this->foreignKey);
 
-        $getter->setBody('return $this->getRef('.var_export($this->foreignKey->getName(), true).', '.var_export($tableName, true).');');
+        $getter->setBody('return $this->getRef('.var_export($tdbmFk->getCacheKey(), true).', '.var_export($tableName, true).');');
 
         if ($this->isGetterProtected()) {
             $getter->setVisibility(AbstractMemberGenerator::VISIBILITY_PROTECTED);
@@ -172,7 +174,7 @@ class ObjectBeanPropertyDescriptor extends AbstractBeanPropertyDescriptor
 
         $setter->setReturnType('void');
 
-        $setter->setBody('$this->setRef('.var_export($this->foreignKey->getName(), true).', $object, '.var_export($tableName, true).');');
+        $setter->setBody('$this->setRef('.var_export($tdbmFk->getCacheKey(), true).', $object, '.var_export($tableName, true).');');
 
         if ($this->isSetterProtected()) {
             $setter->setVisibility(AbstractMemberGenerator::VISIBILITY_PROTECTED);


### PR DESCRIPTION
### Setup:
- UserA generates keys:
    - `key1`: `local(dist_1_id) => dist_1(id)`
    - `key2`: `local(dist_2_id) => dist_2(id)`
- UserB generates keys: (inversed)
    - `key1`: `local(dist_2_id) => dist_2(id)`
    - `key2`: `local(dist_1_id) => dist_1(id)`

### Before:

Use of SQL Foreign Key names could cause conflict on auto-generated key. Each users will have different files, and on Database Query on `key1` UserA will retrieve `dist_1` while UserB will retrieve `dist_2`


### After:

Key names are internal and doesn't depend on SQL keys so both users will retrieve the same object