### PR TITLE
Performance: adding cache for results of FindObjectsQueryFactory::compute

### DIFF
--- a/src/QueryFactory/FindObjectsQueryFactory.php
+++ b/src/QueryFactory/FindObjectsQueryFactory.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\TDBM\QueryFactory;
 
+use Doctrine\Common\Cache\Cache;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use TheCodingMachine\TDBM\OrderByAnalyzer;
@@ -16,17 +17,32 @@ class FindObjectsQueryFactory extends AbstractQueryFactory
     private $mainTable;
     private $additionalTablesFetch;
     private $filterString;
+    /**
+     * @var Cache
+     */
+    private $cache;
 
-    public function __construct(string $mainTable, array $additionalTablesFetch, $filterString, $orderBy, TDBMService $tdbmService, Schema $schema, OrderByAnalyzer $orderByAnalyzer)
+    public function __construct(string $mainTable, array $additionalTablesFetch, $filterString, $orderBy, TDBMService $tdbmService, Schema $schema, OrderByAnalyzer $orderByAnalyzer, Cache $cache)
     {
         parent::__construct($tdbmService, $schema, $orderByAnalyzer, $orderBy);
         $this->mainTable = $mainTable;
         $this->additionalTablesFetch = $additionalTablesFetch;
         $this->filterString = $filterString;
+        $this->cache = $cache;
     }
 
     protected function compute(): void
     {
+        $key = 'FindObjectsQueryFactory_'.$this->mainTable.'__'.implode('_/_',$this->additionalTablesFetch).'__'.$this->filterString.'__'.$this->orderBy;
+        if ($this->cache->contains($key)) {
+            [
+                $this->magicSql,
+                $this->magicSqlCount,
+                $this->columnDescList
+            ] = $this->cache->fetch($key);
+            return;
+        }
+
         list($columnDescList, $columnsList, $orderString) = $this->getColumnsList($this->mainTable, $this->additionalTablesFetch, $this->orderBy, true);
 
         $sql = 'SELECT DISTINCT '.implode(', ', $columnsList).' FROM MAGICJOIN('.$this->mainTable.')';
@@ -54,5 +70,11 @@ class FindObjectsQueryFactory extends AbstractQueryFactory
         $this->magicSql = $sql;
         $this->magicSqlCount = $countSql;
         $this->columnDescList = $columnDescList;
+
+        $this->cache->save($key, [
+            $this->magicSql,
+            $this->magicSqlCount,
+            $this->columnDescList,
+        ]);
     }
 }

--- a/src/TDBMService.php
+++ b/src/TDBMService.php
@@ -1116,7 +1116,7 @@ class TDBMService
 
         $parameters = array_merge($parameters, $additionalParameters);
 
-        $queryFactory = new FindObjectsQueryFactory($mainTable, $additionalTablesFetch, $filterString, $orderString, $this, $this->tdbmSchemaAnalyzer->getSchema(), $this->orderByAnalyzer);
+        $queryFactory = new FindObjectsQueryFactory($mainTable, $additionalTablesFetch, $filterString, $orderString, $this, $this->tdbmSchemaAnalyzer->getSchema(), $this->orderByAnalyzer, $this->cache);
 
         return new ResultIterator($queryFactory, $parameters, $this->objectStorage, $className, $this, $this->magicQuery, $mode, $this->logger);
     }

--- a/src/UncheckedOrderBy.php
+++ b/src/UncheckedOrderBy.php
@@ -35,4 +35,12 @@ class UncheckedOrderBy
     {
         return $this->orderBy;
     }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return 'UncheckedOrderBy_'.$this->orderBy;
+    }
 }


### PR DESCRIPTION
This new cache can speed up to 20% repeated requests.