### PR TITLE
Added parenthesis around AND in filters array

### DIFF
--- a/src/TDBMService.php
+++ b/src/TDBMService.php
@@ -387,7 +387,7 @@ class TDBMService
      */
     public function buildFilterFromFilterBag($filter_bag, AbstractPlatform $platform, int $counter = 1): array
     {
-        if ($filter_bag === null) {
+        if ($filter_bag === null || $filter_bag === []) {
             return ['', [], $counter];
         } elseif (is_string($filter_bag)) {
             return [$filter_bag, [], $counter];
@@ -412,7 +412,7 @@ class TDBMService
                 }
             }
 
-            return [implode(' AND ', $sqlParts), $parameters, $counter];
+            return ['(' . implode(') AND (', $sqlParts) . ')', $parameters, $counter];
         } elseif ($filter_bag instanceof AbstractTDBMObject) {
             $sqlParts = [];
             $parameters = [];


### PR DESCRIPTION
When sending parameter with OR, the parenthesis are misplaced (by MagicQuery ?)
There are only parenthesis around AND, but not around OR