### PR TITLE
Base DAOs and beans should be abstract

### DIFF
--- a/doc/graphqlite.md
+++ b/doc/graphqlite.md
@@ -167,3 +167,40 @@ $db->table('users')
    ->column('name')->string(50)->graphqlField()
    ->logged()->right('CAN_SEE_NAME')->failWith(null);
 ```
+
+## Use your beans as input types
+
+TDBM will automatically annotate the `xxxDao::getById()` method with a `@Factory` annotation.
+As a result, you can directly inject you beans as arguments in your GraphQL queries.
+
+For instance:
+
+```php
+class ProductController
+{
+    // ...
+
+    /**
+     * @Query()
+     * @return Product[]
+     */
+    public function getProducts(Category $category): array
+    {
+        // ...
+    }
+}
+```
+
+Assuming "Category" is a bean, TDBM-GraphQL will automatically fetch the bean from the database and populate the `$category`
+argument with it.
+
+Your GraphQL query will look like this:
+
+```graphql
+{
+    products(category: { id: 42 }) {
+        id
+        name
+    }
+}
+```

--- a/src/Utils/BeanDescriptor.php
+++ b/src/Utils/BeanDescriptor.php
@@ -495,6 +495,7 @@ class BeanDescriptor implements BeanDescriptorInterface
 
         $file = new FileGenerator();
         $class = new ClassGenerator();
+        $class->setAbstract(true);
         $file->setClass($class);
         $file->setNamespace($this->generatedBeanNamespace);
 
@@ -651,6 +652,7 @@ EOF
     {
         $file = new FileGenerator();
         $class = new ClassGenerator();
+        $class->setAbstract(true);
         $file->setClass($class);
         $file->setNamespace($this->generatedDaoNamespace);
 

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -1988,6 +1988,9 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
         $this->assertTrue($refClass->implementsInterface(TestUserDaoInterface::class));
     }
 
+    /**
+     * @depends testDaoGeneration
+     */
     public function testTrait()
     {
         if (!$this->tdbmService->getConnection()->getDatabasePlatform() instanceof MySqlPlatform) {
@@ -2003,5 +2006,17 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
 
         $refClass = new ReflectionClass(UserBaseDao::class);
         $this->assertTrue($refClass->hasMethod('findNothing'));
+    }
+
+    /**
+     * @depends testDaoGeneration
+     */
+    public function testNonInstantiableAbstractDaosAndBeans()
+    {
+        $refClass = new ReflectionClass(UserBaseDao::class);
+        $this->assertFalse($refClass->isInstantiable());
+
+        $refClass = new ReflectionClass(UserBaseBean::class);
+        $this->assertFalse($refClass->isInstantiable());
     }
 }


### PR DESCRIPTION
They are currently not abstract. This is probably a regression introduced in TDBM 5.1