### PR TITLE
 Enabling PHP 7.3 tests again 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ before_script:
 script:
 # Let's run the Oracle script only when the password is available (it is not available in forks unfortunately)
 - |
-  if [[ "$COVERALLS" -ne "true" ]] ; then export NO_COVERAGE="--no-coverage"; fi;
+  if [[ "$COVERALLS" != "true" ]] ; then export NO_COVERAGE="--no-coverage"; fi;
   if [ "$DB" == "oracle" ] ; then
     docker run -v $(pwd):/app -v $(pwd)/tests/Fixtures/oracle-startup.sql:/docker-entrypoint-initdb.d/oracle-startup.sql moufmouf/oracle-xe-php vendor/bin/phpunit $PHPUNITFILE $NO_COVERAGE;
   elif [ "$DB" == "mysql8" ] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ script:
     sudo /etc/init.d/mysql stop;
     tests/phpunit-mysql8.sh
   else
+    echo ./vendor/bin/phpunit $PHPUNITFILE $NO_COVERAGE;
     ./vendor/bin/phpunit $PHPUNITFILE $NO_COVERAGE;
   fi
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_script:
 - if [ -z "$NO_WEAKREF" ] ; then pecl install weakref-beta; fi
 script:
 # Let's run the Oracle script only when the password is available (it is not available in forks unfortunately)
-- if [[ "$COVERALLS" -ne "true" ]] ; export NO_COVERAGE="--no-coverage"; fi;
+- if [[ "$COVERALLS" -ne "true" ]] ; then export NO_COVERAGE="--no-coverage"; fi;
 - |
   if [ "$DB" == "oracle" ] ; then
     docker run -v $(pwd):/app -v $(pwd)/tests/Fixtures/oracle-startup.sql:/docker-entrypoint-initdb.d/oracle-startup.sql moufmouf/oracle-xe-php vendor/bin/phpunit $PHPUNITFILE $NO_COVERAGE;

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_script:
 - if [ -z "$NO_WEAKREF" ] ; then pecl install weakref-beta; fi
 script:
 # Let's run the Oracle script only when the password is available (it is not available in forks unfortunately)
-- if [ "$COVERALLS" -ne "true" ] ; export NO_COVERAGE="--no-coverage"; fi;
+- if [[ "$COVERALLS" -ne "true" ]] ; export NO_COVERAGE="--no-coverage"; fi;
 - |
   if [ "$DB" == "oracle" ] ; then
     docker run -v $(pwd):/app -v $(pwd)/tests/Fixtures/oracle-startup.sql:/docker-entrypoint-initdb.d/oracle-startup.sql moufmouf/oracle-xe-php vendor/bin/phpunit $PHPUNITFILE $NO_COVERAGE;

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,8 @@ before_script:
 - if [ -z "$NO_WEAKREF" ] ; then pecl install weakref-beta; fi
 script:
 # Let's run the Oracle script only when the password is available (it is not available in forks unfortunately)
-- if [[ "$COVERALLS" -ne "true" ]] ; then export NO_COVERAGE="--no-coverage"; fi;
 - |
+  if [[ "$COVERALLS" -ne "true" ]] ; then export NO_COVERAGE="--no-coverage"; fi;
   if [ "$DB" == "oracle" ] ; then
     docker run -v $(pwd):/app -v $(pwd)/tests/Fixtures/oracle-startup.sql:/docker-entrypoint-initdb.d/oracle-startup.sql moufmouf/oracle-xe-php vendor/bin/phpunit $PHPUNITFILE $NO_COVERAGE;
   elif [ "$DB" == "mysql8" ] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
     - $HOME/.composer/cache
 matrix:
   include:
+    - php: 7.3
+      env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
     - php: 7.2
       env: PREFER_LOWEST="" DB=mysql
     - php: 7.1
@@ -52,9 +54,6 @@ matrix:
       env: PREFER_LOWEST="" DB=oracle PHPUNITFILE="-c phpunit.oracle.xml"
     - php: 7.1
       env: PREFER_LOWEST="--prefer-lowest" DB=oracle PHPUNITFILE="-c phpunit.oracle.xml"
-    # 7.3 allowed to fail due to an issue with greenlion/PHP-SQL-Parser: https://github.com/greenlion/PHP-SQL-Parser/pull/304
-    - php: 7.3
-      env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
 env:
   global:
   - GIT_NAME: "'Couscous auto deploy'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ cache:
     - $HOME/.composer/cache
 matrix:
   include:
+    - php: 7.2
+      env: PREFER_LOWEST="" DB=mysql RUN_PHPSTAN=1 RUN_CSCHECK=1 RUN_REQUIRECHECKER=1
     - php: 7.3
       env: PREFER_LOWEST="" DB=mysql NO_WEAKREF=1
-    - php: 7.2
-      env: PREFER_LOWEST="" DB=mysql
     - php: 7.1
       env: PREFER_LOWEST="" DB=mysql COVERALLS=true
     - php: 7.1
@@ -67,18 +67,28 @@ before_script:
 - if [ -z "$NO_WEAKREF" ] ; then pecl install weakref-beta; fi
 script:
 # Let's run the Oracle script only when the password is available (it is not available in forks unfortunately)
+- if [ "$COVERALLS" -ne "true" ] ; export NO_COVERAGE="--no-coverage"; fi;
 - |
   if [ "$DB" == "oracle" ] ; then
-    docker run -v $(pwd):/app -v $(pwd)/tests/Fixtures/oracle-startup.sql:/docker-entrypoint-initdb.d/oracle-startup.sql moufmouf/oracle-xe-php vendor/bin/phpunit $PHPUNITFILE;
+    docker run -v $(pwd):/app -v $(pwd)/tests/Fixtures/oracle-startup.sql:/docker-entrypoint-initdb.d/oracle-startup.sql moufmouf/oracle-xe-php vendor/bin/phpunit $PHPUNITFILE $NO_COVERAGE;
   elif [ "$DB" == "mysql8" ] ; then
     sudo /etc/init.d/mysql stop;
     tests/phpunit-mysql8.sh
   else
-    ./vendor/bin/phpunit $PHPUNITFILE;
+    ./vendor/bin/phpunit $PHPUNITFILE $NO_COVERAGE;
   fi
-- composer cscheck
-- composer phpstan
-- composer require-checker
+- |
+  if [ "$RUN_CSCHECK" == "1" ] ; then
+    composer cscheck
+  fi
+- |
+  if [ "$RUN_PHPSTAN" == "1" ] ; then
+    composer phpstan
+  fi
+- |
+  if [ "$RUN_REQUIRECHECKER" == "1" ] ; then
+    composer require-checker
+  fi
 after_script:
 - if [ "$COVERALLS" = "true" ] ; then ./vendor/bin/coveralls -v; fi
 - if [ "$COVERALLS" = "true" ] ; then vendor/bin/couscous travis-auto-deploy --php-version=7.1 -vvv; fi

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "beberlei/porpaginas": "~1.0",
         "mouf/classname-mapper": "~1.0",
         "doctrine/cache": "^1.6",
-        "greenlion/php-sql-parser": "^4.1.2",
+        "greenlion/php-sql-parser": "^4.3.0",
         "phlib/logger": "^3.0.1",
         "symfony/console": "^2 || ^3 || ^4",
         "mouf/utils.log.psr.multi-logger": "^1.0",

--- a/tests/phpunit-mysql8.sh
+++ b/tests/phpunit-mysql8.sh
@@ -11,7 +11,7 @@ docker run --rm --name mysql8-tdbm-test -p 3306:3306 -p 33060:33060 -e MYSQL_ROO
 # Let's wait for MySQL 8 to start
 sleep 20
 
-vendor/bin/phpunit -c phpunit.mysql8.xml
+vendor/bin/phpunit -c phpunit.mysql8.xml $NO_COVERAGE
 RESULT_CODE=$?
 
 docker stop mysql8-tdbm-test


### PR DESCRIPTION
Now that PHP-SQL-Parser 4.3.0 is released (https://github.com/greenlion/PHP-SQL-Parser/releases/tag/4.3.0) \o/, we can enable PHP 7.3 tests again.