### PR TITLE
InnerResultIterator: Improve count() performance of non-executed query

### DIFF
--- a/src/AlterableResultIterator.php
+++ b/src/AlterableResultIterator.php
@@ -222,6 +222,9 @@ class AlterableResultIterator implements Result, \ArrayAccess, \JsonSerializable
      */
     public function count()
     {
+        if ($this->resultIterator instanceof \Countable && $this->alterations->count() === 0) {
+            return $this->resultIterator->count();
+        }
         return count($this->toArray());
     }
 

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -964,6 +964,17 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
     /**
      * @depends testDaoGeneration
      */
+    public function testInnerResultIteratorCountAfterFetch(): void
+    {
+        $userDao = new TestUserDao($this->tdbmService);
+        $users = $userDao->getUsersByLoginStartingWith('j')->take(0, 4);
+        $users->toArray(); // We force to fetch
+        $this->assertEquals(3, $users->count());
+    }
+
+    /**
+     * @depends testDaoGeneration
+     */
     public function testFirst(): void
     {
         $userDao = new TestUserDao($this->tdbmService);


### PR DESCRIPTION
Previously this would have execute the query under MySQL, on large result set the executed query could have slow the application