### PR TITLE
Creating an abstraction on top of InnerResultIterator

### DIFF
--- a/src/AlterableResultIterator.php
+++ b/src/AlterableResultIterator.php
@@ -16,7 +16,7 @@ use Porpaginas\Result;
 class AlterableResultIterator implements Result, \ArrayAccess, \JsonSerializable
 {
     /**
-     * @var \Iterator|null
+     * @var \Traversable|null
      */
     private $resultIterator;
 
@@ -37,9 +37,9 @@ class AlterableResultIterator implements Result, \ArrayAccess, \JsonSerializable
     private $resultArray;
 
     /**
-     * @param \Iterator|null $resultIterator
+     * @param \Traversable|null $resultIterator
      */
-    public function __construct(\Iterator $resultIterator = null)
+    public function __construct(\Traversable $resultIterator = null)
     {
         $this->resultIterator = $resultIterator;
         $this->alterations = new \SplObjectStorage();
@@ -48,9 +48,9 @@ class AlterableResultIterator implements Result, \ArrayAccess, \JsonSerializable
     /**
      * Sets a new iterator as the base iterator to be altered.
      *
-     * @param \Iterator $resultIterator
+     * @param \Traversable $resultIterator
      */
-    public function setResultIterator(\Iterator $resultIterator): void
+    public function setResultIterator(\Traversable $resultIterator): void
     {
         $this->resultIterator = $resultIterator;
         $this->resultArray = null;
@@ -59,9 +59,9 @@ class AlterableResultIterator implements Result, \ArrayAccess, \JsonSerializable
     /**
      * Returns the non altered result iterator (or null if none exist).
      *
-     * @return \Iterator|null
+     * @return \Traversable|null
      */
-    public function getUnderlyingResultIterator(): ?\Iterator
+    public function getUnderlyingResultIterator(): ?\Traversable
     {
         return $this->resultIterator;
     }
@@ -231,7 +231,7 @@ class AlterableResultIterator implements Result, \ArrayAccess, \JsonSerializable
     /**
      * Return an iterator over all results of the paginatable.
      *
-     * @return \Iterator
+     * @return \Traversable
      */
     public function getIterator()
     {

--- a/src/EmptyInnerResultIterator.php
+++ b/src/EmptyInnerResultIterator.php
@@ -1,0 +1,143 @@
+<?php
+
+
+namespace TheCodingMachine\TDBM;
+
+use Iterator;
+
+/**
+ * @internal
+ */
+class EmptyInnerResultIterator implements Iterator, InnerResultIteratorInterface
+{
+
+    /**
+     * Return the current element
+     * @link https://php.net/manual/en/iterator.current.php
+     * @return mixed Can return any type.
+     * @since 5.0.0
+     */
+    public function current()
+    {
+        return null;
+    }
+
+    /**
+     * Move forward to next element
+     * @link https://php.net/manual/en/iterator.next.php
+     * @return void Any returned value is ignored.
+     * @since 5.0.0
+     */
+    public function next()
+    {
+    }
+
+    /**
+     * Return the key of the current element
+     * @link https://php.net/manual/en/iterator.key.php
+     * @return mixed scalar on success, or null on failure.
+     * @since 5.0.0
+     */
+    public function key()
+    {
+        return null;
+    }
+
+    /**
+     * Checks if current position is valid
+     * @link https://php.net/manual/en/iterator.valid.php
+     * @return boolean The return value will be casted to boolean and then evaluated.
+     * Returns true on success or false on failure.
+     * @since 5.0.0
+     */
+    public function valid()
+    {
+        return false;
+    }
+
+    /**
+     * Rewind the Iterator to the first element
+     * @link https://php.net/manual/en/iterator.rewind.php
+     * @return void Any returned value is ignored.
+     * @since 5.0.0
+     */
+    public function rewind()
+    {
+    }
+
+    /**
+     * Whether a offset exists
+     * @link https://php.net/manual/en/arrayaccess.offsetexists.php
+     * @param mixed $offset <p>
+     * An offset to check for.
+     * </p>
+     * @return boolean true on success or false on failure.
+     * </p>
+     * <p>
+     * The return value will be casted to boolean if non-boolean was returned.
+     * @since 5.0.0
+     */
+    public function offsetExists($offset)
+    {
+        return false;
+    }
+
+    /**
+     * Offset to retrieve
+     * @link https://php.net/manual/en/arrayaccess.offsetget.php
+     * @param mixed $offset <p>
+     * The offset to retrieve.
+     * </p>
+     * @return mixed Can return all value types.
+     * @since 5.0.0
+     */
+    public function offsetGet($offset)
+    {
+        throw new TDBMInvalidOffsetException('Offset "'.$offset.'" does not exist in result set.');
+    }
+
+    /**
+     * Offset to set
+     * @link https://php.net/manual/en/arrayaccess.offsetset.php
+     * @param mixed $offset <p>
+     * The offset to assign the value to.
+     * </p>
+     * @param mixed $value <p>
+     * The value to set.
+     * </p>
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetSet($offset, $value)
+    {
+        throw new TDBMInvalidOperationException('You cannot set values in a TDBM result set.');
+    }
+
+    /**
+     * Offset to unset
+     * @link https://php.net/manual/en/arrayaccess.offsetunset.php
+     * @param mixed $offset <p>
+     * The offset to unset.
+     * </p>
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetUnset($offset)
+    {
+        throw new TDBMInvalidOperationException('You cannot unset values in a TDBM result set.');
+    }
+
+    /**
+     * Count elements of an object
+     * @link https://php.net/manual/en/countable.count.php
+     * @return int The custom count as an integer.
+     * </p>
+     * <p>
+     * The return value is cast to an integer.
+     * @since 5.1.0
+     */
+    public function count()
+    {
+        return 0;
+    }
+}

--- a/src/InnerResultArray.php
+++ b/src/InnerResultArray.php
@@ -53,9 +53,6 @@ class InnerResultArray extends InnerResultIterator
      */
     public function offsetExists($offset)
     {
-        if ($this->count === 0) {
-            return false;
-        }
         try {
             $this->toIndex($offset);
         } catch (TDBMInvalidOffsetException $e) {
@@ -125,9 +122,6 @@ class InnerResultArray extends InnerResultIterator
      */
     public function rewind()
     {
-        if ($this->count === 0) {
-            return;
-        }
         if (!$this->fetchStarted) {
             $this->executeQuery();
         }

--- a/src/InnerResultIterator.php
+++ b/src/InnerResultIterator.php
@@ -93,14 +93,6 @@ class InnerResultIterator implements \Iterator, InnerResultIteratorInterface
         return $iterator;
     }
 
-    public static function createEmpyIterator(): self
-    {
-        $iterator = new static();
-        $iterator->count = 0;
-        $iterator->logger = new NullLogger();
-        return $iterator;
-    }
-
     private function getQuery(): string
     {
         $sql = $this->magicQuery->buildPreparedStatement($this->magicSql, $this->parameters);

--- a/src/InnerResultIterator.php
+++ b/src/InnerResultIterator.php
@@ -31,7 +31,7 @@ use TheCodingMachine\TDBM\Utils\DbalUtils;
 /**
  * Iterator used to retrieve results.
  */
-class InnerResultIterator implements \Iterator, \Countable, \ArrayAccess
+class InnerResultIterator implements \Iterator, InnerResultIteratorInterface
 {
     /**
      * @var Statement
@@ -258,9 +258,6 @@ class InnerResultIterator implements \Iterator, \Countable, \ArrayAccess
      */
     public function rewind()
     {
-        if ($this->count === 0) {
-            return;
-        }
         $this->executeQuery();
         $this->key = -1;
         $this->next();
@@ -272,9 +269,6 @@ class InnerResultIterator implements \Iterator, \Countable, \ArrayAccess
      */
     public function valid()
     {
-        if ($this->count === 0) {
-            return false;
-        }
         return $this->current !== null;
     }
 

--- a/src/InnerResultIteratorInterface.php
+++ b/src/InnerResultIteratorInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace TheCodingMachine\TDBM;
+
+/**
+ * Interface implemented by all "inner result iterators"
+ */
+interface InnerResultIteratorInterface extends \Traversable, \Countable, \ArrayAccess
+{
+}

--- a/src/MapIterator.php
+++ b/src/MapIterator.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace TheCodingMachine\TDBM;
 
 use Iterator;
+use IteratorAggregate;
+use Traversable;
 
 /**
  * An iterator that maps element of another iterator by calling a callback on it.
@@ -22,7 +24,7 @@ class MapIterator implements Iterator, \JsonSerializable
     protected $callable;
 
     /**
-     * @param Iterator|array $iterator
+     * @param Traversable|array $iterator
      * @param callable $callable This can have two parameters
      *
      * @throws TDBMException
@@ -31,10 +33,15 @@ class MapIterator implements Iterator, \JsonSerializable
     {
         if (is_array($iterator)) {
             $this->iterator = new \ArrayIterator($iterator);
-        } elseif (!($iterator instanceof Iterator)) {
-            throw new TDBMException('$iterator parameter must be an instance of Iterator');
-        } else {
+        } elseif ($iterator instanceof Iterator) {
             $this->iterator = $iterator;
+        } elseif ($iterator instanceof IteratorAggregate) {
+            while (!$iterator instanceof Iterator) {
+                $iterator = $iterator->getIterator();
+            }
+            $this->iterator = $iterator;
+        } else {
+            throw new TDBMException('$iterator parameter must be an instance of Iterator');
         }
 
         if ($callable instanceof \Closure) {

--- a/src/PageIterator.php
+++ b/src/PageIterator.php
@@ -105,18 +105,13 @@ class PageIterator implements Page, \ArrayAccess, \JsonSerializable
     /**
      * Retrieve an external iterator.
      *
-     * @link http://php.net/manual/en/iteratoraggregate.getiterator.php
-     *
-     * @return InnerResultIterator An instance of an object implementing <b>Iterator</b> or
-     *                             <b>Traversable</b>
-     *
-     * @since 5.0.0
+     * @return InnerResultIteratorInterface
      */
     public function getIterator()
     {
         if ($this->innerResultIterator === null) {
             if ($this->parentResult->count() === 0) {
-                $this->innerResultIterator = InnerResultIterator::createEmpyIterator();
+                $this->innerResultIterator = new EmptyInnerResultIterator();
             } elseif ($this->mode === TDBMService::MODE_CURSOR) {
                 $this->innerResultIterator = InnerResultIterator::createInnerResultIterator($this->magicSql, $this->parameters, $this->limit, $this->offset, $this->columnDescriptors, $this->objectStorage, $this->className, $this->tdbmService, $this->magicQuery, $this->logger);
             } else {
@@ -251,7 +246,7 @@ class PageIterator implements Page, \ArrayAccess, \JsonSerializable
      */
     public function offsetSet($offset, $value)
     {
-        return $this->getIterator()->offsetSet($offset, $value);
+        $this->getIterator()->offsetSet($offset, $value);
     }
 
     /**
@@ -267,7 +262,7 @@ class PageIterator implements Page, \ArrayAccess, \JsonSerializable
      */
     public function offsetUnset($offset)
     {
-        return $this->getIterator()->offsetUnset($offset);
+        $this->getIterator()->offsetUnset($offset);
     }
 
     /**

--- a/src/ResultIterator.php
+++ b/src/ResultIterator.php
@@ -65,7 +65,7 @@ class ResultIterator implements Result, \ArrayAccess, \JsonSerializable
     private $queryFactory;
 
     /**
-     * @var InnerResultIterator|null
+     * @var InnerResultIteratorInterface|null
      */
     private $innerResultIterator;
 
@@ -160,18 +160,13 @@ class ResultIterator implements Result, \ArrayAccess, \JsonSerializable
     /**
      * Retrieve an external iterator.
      *
-     * @link http://php.net/manual/en/iteratoraggregate.getiterator.php
-     *
-     * @return InnerResultIterator An instance of an object implementing <b>Iterator</b> or
-     *                             <b>Traversable</b>
-     *
-     * @since 5.0.0
+     * @return InnerResultIteratorInterface
      */
     public function getIterator()
     {
         if ($this->innerResultIterator === null) {
             if ($this->totalCount === 0) {
-                $this->innerResultIterator = InnerResultArray::createEmpyIterator();
+                $this->innerResultIterator = new EmptyInnerResultIterator();
             } elseif ($this->mode === TDBMService::MODE_CURSOR) {
                 $this->innerResultIterator = InnerResultIterator::createInnerResultIterator($this->queryFactory->getMagicSql(), $this->parameters, null, null, $this->queryFactory->getColumnDescriptors(), $this->objectStorage, $this->className, $this->tdbmService, $this->magicQuery, $this->logger);
             } else {
@@ -251,7 +246,7 @@ class ResultIterator implements Result, \ArrayAccess, \JsonSerializable
      */
     public function offsetSet($offset, $value)
     {
-        return $this->getIterator()->offsetSet($offset, $value);
+        $this->getIterator()->offsetSet($offset, $value);
     }
 
     /**
@@ -267,7 +262,7 @@ class ResultIterator implements Result, \ArrayAccess, \JsonSerializable
      */
     public function offsetUnset($offset)
     {
-        return $this->getIterator()->offsetUnset($offset);
+        $this->getIterator()->offsetUnset($offset);
     }
 
     /**

--- a/tests/EmptyInnerResultIteratorTest.php
+++ b/tests/EmptyInnerResultIteratorTest.php
@@ -38,7 +38,10 @@ class EmptyInnerResultIteratorTest extends TestCase
         foreach ($iterator as $elem) {
             $this->fail('Iterator should be empty');
         }
-        $this->assertTrue(true);
+
+        $iterator->next();
+        $this->assertNull($iterator->current());
+        $this->assertNull($iterator->key());
     }
 
     public function testOffsetGet()

--- a/tests/EmptyInnerResultIteratorTest.php
+++ b/tests/EmptyInnerResultIteratorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace TheCodingMachine\TDBM;
+
+use PHPUnit\Framework\TestCase;
+
+class EmptyInnerResultIteratorTest extends TestCase
+{
+    public function testOffsetUnset()
+    {
+        $iterator = new EmptyInnerResultIterator();
+        $this->expectException(TDBMInvalidOperationException::class);
+        unset($iterator[42]);
+    }
+
+    public function testCount()
+    {
+        $iterator = new EmptyInnerResultIterator();
+        $this->assertCount(0, $iterator);
+    }
+
+    public function testOffsetExists()
+    {
+        $iterator = new EmptyInnerResultIterator();
+        $this->assertFalse(isset($iterator[0]));
+    }
+
+    public function testOffsetSet()
+    {
+        $iterator = new EmptyInnerResultIterator();
+        $this->expectException(TDBMInvalidOperationException::class);
+        $iterator[42] = 'foo';
+    }
+
+    public function testIterate()
+    {
+        $iterator = new EmptyInnerResultIterator();
+        foreach ($iterator as $elem) {
+            $this->fail('Iterator should be empty');
+        }
+        $this->assertTrue(true);
+    }
+
+    public function testOffsetGet()
+    {
+        $iterator = new EmptyInnerResultIterator();
+        $this->expectException(TDBMInvalidOffsetException::class);
+        $iterator[42];
+    }
+}

--- a/tests/MapIteratorTest.php
+++ b/tests/MapIteratorTest.php
@@ -29,19 +29,18 @@ class MapIteratorTest extends TestCase
 {
     public function testIteratorAggregate(): void
     {
-        $mapIterator = new MapIterator(new class implements IteratorAggregate
-            {
-                public $property1 = "Public property one";
-                public $property2 = "Public property two";
-                public $property3 = "Public property three";
+        $mapIterator = new MapIterator(new class implements IteratorAggregate {
+            public $property1 = "Public property one";
+            public $property2 = "Public property two";
+            public $property3 = "Public property three";
 
-                public function getIterator()
-                {
-                    return new ArrayIterator($this);
-                }
-            }, function ($item) {
-                return $item;
-            });
+            public function getIterator()
+            {
+                return new ArrayIterator($this);
+            }
+        }, function ($item) {
+            return $item;
+        });
 
         self::assertCount(3, $mapIterator);
     }

--- a/tests/MapIteratorTest.php
+++ b/tests/MapIteratorTest.php
@@ -21,10 +21,31 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 namespace TheCodingMachine\TDBM;
 
+use ArrayIterator;
+use IteratorAggregate;
 use PHPUnit\Framework\TestCase;
 
 class MapIteratorTest extends TestCase
 {
+    public function testIteratorAggregate(): void
+    {
+        $mapIterator = new MapIterator(new class implements IteratorAggregate
+            {
+                public $property1 = "Public property one";
+                public $property2 = "Public property two";
+                public $property3 = "Public property three";
+
+                public function getIterator()
+                {
+                    return new ArrayIterator($this);
+                }
+            }, function ($item) {
+                return $item;
+            });
+
+        self::assertCount(3, $mapIterator);
+    }
+
     public function testConstructorException1(): void
     {
         $this->expectException('TheCodingMachine\TDBM\TDBMException');


### PR DESCRIPTION
Migrates the EmptyInnerResultIterator out of the class InnerResultIterator.
In the future, we will be able to create a "StaticInnerResultIterator" containing a static array.