### PR TITLE
Adding a @ReadOnly annotation

### DIFF
--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -179,6 +179,28 @@ This annotation can be put on a column comment to alter the visibility of the "i
 For instance, if you put the `@ProtectedOneToMany` on the "country_id" column of a "users" table,
 then in the `Country` bean, the `getUsers()` method will be protected.
 
+The @ReadOnly annotation
+-----------------------------------------------------
+<small>(Available in TDBM 5.2+)</small>
+
+Columns with the "@ReadOnly" annotation cannot be written at all by TDBM.
+
+Add this annotation to any column that is generated/computed in your database.
+
+For instance:
+
+```sql
+CREATE TABLE `products` (
+    `id` INT UNSIGNED AUTO_INCREMENT NOT NULL,
+    `data` JSON NOT NULL,
+    `names_virtual` VARCHAR(20) GENERATED ALWAYS AS (`data` ->> '$.name') NOT NULL COMMENT '@Generated', 
+    PRIMARY KEY (`id`)
+)
+```
+
+Note: TDBM is based in Doctrine DBAL and Doctrine DBAL offers no way of knowing which columns are computed. So each time
+you have a generated column in your data model, you will need to put the `@Generated` annotation explicitly. 
+
 The @Json annotations
 ---------------------
 

--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -193,13 +193,13 @@ For instance:
 CREATE TABLE `products` (
     `id` INT UNSIGNED AUTO_INCREMENT NOT NULL,
     `data` JSON NOT NULL,
-    `names_virtual` VARCHAR(20) GENERATED ALWAYS AS (`data` ->> '$.name') NOT NULL COMMENT '@Generated', 
+    `names_virtual` VARCHAR(20) GENERATED ALWAYS AS (`data` ->> '$.name') NOT NULL COMMENT '@ReadOnly', 
     PRIMARY KEY (`id`)
 )
 ```
 
 Note: TDBM is based in Doctrine DBAL and Doctrine DBAL offers no way of knowing which columns are computed. So each time
-you have a generated column in your data model, you will need to put the `@Generated` annotation explicitly. 
+you have a generated column in your data model, you will need to put the `@ReadOnly` annotation explicitly. 
 
 The @Json annotations
 ---------------------

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,6 +23,9 @@ parameters:
      -
         message: '#TheCodingMachine\\TDBM\\Schema\\LockFileSchemaManager::__construct\(\) does not call parent constructor from Doctrine\\DBAL\\Schema\\AbstractSchemaManager.#'
         path: src/Schema/LockFileSchemaManager.php
+     -
+        message: '#is "array". Please provide a more specific .* annotation#'
+        path: src/Test/Dao/Bean/Generated/PlayerBaseBean.php
     #reportUnmatchedIgnoredErrors: false
 includes:
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/Utils/AbstractBeanPropertyDescriptor.php
+++ b/src/Utils/AbstractBeanPropertyDescriptor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace TheCodingMachine\TDBM\Utils;
 
 use Doctrine\DBAL\Schema\Table;
+use TheCodingMachine\TDBM\Utils\Annotation\ReadOnly;
 use Zend\Code\Generator\DocBlock\Tag\ParamTag;
 use Zend\Code\Generator\MethodGenerator;
 
@@ -149,7 +150,7 @@ abstract class AbstractBeanPropertyDescriptor implements MethodDescriptorInterfa
     /**
      * Returns the PHP code for getters and setters.
      *
-     * @return MethodGenerator[]
+     * @return (MethodGenerator|null)[]
      */
     abstract public function getGetterSetterCode(): array;
 
@@ -180,4 +181,12 @@ abstract class AbstractBeanPropertyDescriptor implements MethodDescriptorInterfa
      * @return bool
      */
     abstract public function isTypeHintable() : bool;
+
+    /**
+     * Returns true if the property is tagged with the "ReadOnly" annotation.
+     * ReadOnly annotations should be used on generated/computed database columns.
+     *
+     * @return bool
+     */
+    abstract public function isReadOnly(): bool;
 }

--- a/src/Utils/Annotation/AnnotationParser.php
+++ b/src/Utils/Annotation/AnnotationParser.php
@@ -43,6 +43,7 @@ class AnnotationParser
             'ProtectedGetter' => ProtectedGetter::class,
             'ProtectedSetter' => ProtectedSetter::class,
             'ProtectedOneToMany' => ProtectedOneToMany::class,
+            'Generated' => ReadOnly::class,
             'JsonKey' => JsonKey::class,
             'JsonIgnore' => JsonIgnore::class,
             'JsonInclude' => JsonInclude::class,

--- a/src/Utils/Annotation/AnnotationParser.php
+++ b/src/Utils/Annotation/AnnotationParser.php
@@ -43,7 +43,7 @@ class AnnotationParser
             'ProtectedGetter' => ProtectedGetter::class,
             'ProtectedSetter' => ProtectedSetter::class,
             'ProtectedOneToMany' => ProtectedOneToMany::class,
-            'Generated' => ReadOnly::class,
+            'ReadOnly' => ReadOnly::class,
             'JsonKey' => JsonKey::class,
             'JsonIgnore' => JsonIgnore::class,
             'JsonInclude' => JsonInclude::class,

--- a/src/Utils/Annotation/ReadOnly.php
+++ b/src/Utils/Annotation/ReadOnly.php
@@ -1,0 +1,15 @@
+<?php
+namespace TheCodingMachine\TDBM\Utils\Annotation;
+
+/**
+ * Declares a column as "read-only".
+ * Read-only columns cannot be set neither in a setter nor in a constructor argument.
+ * They are very useful on generated/computed columns.
+ *
+ * This annotation can only be used in a database column comment.
+ *
+ * @Annotation
+ */
+final class ReadOnly
+{
+}

--- a/src/Utils/BeanDescriptor.php
+++ b/src/Utils/BeanDescriptor.php
@@ -214,8 +214,8 @@ class BeanDescriptor implements BeanDescriptorInterface
      */
     public function getConstructorProperties(): array
     {
-        $constructorProperties = array_filter($this->beanPropertyDescriptors, function (AbstractBeanPropertyDescriptor $property) {
-            return !$property instanceof InheritanceReferencePropertyDescriptor && $property->isCompulsory();
+        $constructorProperties = array_filter($this->beanPropertyDescriptors, static function (AbstractBeanPropertyDescriptor $property) {
+            return !$property instanceof InheritanceReferencePropertyDescriptor && $property->isCompulsory() && !$property->isReadOnly();
         });
 
         return $constructorProperties;

--- a/tests/TDBMAbstractServiceTest.php
+++ b/tests/TDBMAbstractServiceTest.php
@@ -415,6 +415,17 @@ abstract class TDBMAbstractServiceTest extends TestCase
             $connection->exec($sqlStmt);
         }
 
+        // Let's generate computed columns
+        if ($connection->getDatabasePlatform() instanceof MySqlPlatform) {
+            $connection->exec('CREATE TABLE `players` (
+               `id` INT UNSIGNED AUTO_INCREMENT NOT NULL,
+               `player_and_games` JSON NOT NULL,
+               `names_virtual` VARCHAR(20) GENERATED ALWAYS AS (`player_and_games` ->> \'$.name\') NOT NULL COMMENT \'@Generated\', 
+               PRIMARY KEY (`id`)
+            );
+            ');
+        }
+
         self::insert($connection, 'country', [
             'label' => 'France',
         ]);

--- a/tests/TDBMAbstractServiceTest.php
+++ b/tests/TDBMAbstractServiceTest.php
@@ -421,8 +421,8 @@ abstract class TDBMAbstractServiceTest extends TestCase
             $connection->exec('CREATE TABLE `players` (
                `id` INT UNSIGNED AUTO_INCREMENT NOT NULL,
                `player_and_games` JSON NOT NULL,
-               `names_virtual` VARCHAR(20) GENERATED ALWAYS AS (`player_and_games` ->> \'$.name\') NOT NULL COMMENT \'@Generated\',
-               `animal_id` INT COMMENT \'@Generated\',
+               `names_virtual` VARCHAR(20) GENERATED ALWAYS AS (`player_and_games` ->> \'$.name\') NOT NULL COMMENT \'@ReadOnly\',
+               `animal_id` INT COMMENT \'@ReadOnly\',
                PRIMARY KEY (`id`),
                FOREIGN KEY (animal_id) REFERENCES animal(id)
             );

--- a/tests/TDBMAbstractServiceTest.php
+++ b/tests/TDBMAbstractServiceTest.php
@@ -421,8 +421,10 @@ abstract class TDBMAbstractServiceTest extends TestCase
             $connection->exec('CREATE TABLE `players` (
                `id` INT UNSIGNED AUTO_INCREMENT NOT NULL,
                `player_and_games` JSON NOT NULL,
-               `names_virtual` VARCHAR(20) GENERATED ALWAYS AS (`player_and_games` ->> \'$.name\') NOT NULL COMMENT \'@Generated\', 
-               PRIMARY KEY (`id`)
+               `names_virtual` VARCHAR(20) GENERATED ALWAYS AS (`player_and_games` ->> \'$.name\') NOT NULL COMMENT \'@Generated\',
+               `animal_id` INT COMMENT \'@Generated\',
+               PRIMARY KEY (`id`),
+               FOREIGN KEY (animal_id) REFERENCES animal(id)
             );
             ');
         }

--- a/tests/TDBMAbstractServiceTest.php
+++ b/tests/TDBMAbstractServiceTest.php
@@ -43,6 +43,7 @@ use TheCodingMachine\TDBM\Utils\Annotation\AnnotationParser;
 use TheCodingMachine\TDBM\Utils\Annotation\AddInterface;
 use TheCodingMachine\TDBM\Utils\DefaultNamingStrategy;
 use TheCodingMachine\TDBM\Utils\PathFinder\PathFinder;
+use function stripos;
 
 abstract class TDBMAbstractServiceTest extends TestCase
 {
@@ -416,7 +417,7 @@ abstract class TDBMAbstractServiceTest extends TestCase
         }
 
         // Let's generate computed columns
-        if ($connection->getDatabasePlatform() instanceof MySqlPlatform) {
+        if ($connection->getDatabasePlatform() instanceof MySqlPlatform && !self::isMariaDb($connection)) {
             $connection->exec('CREATE TABLE `players` (
                `id` INT UNSIGNED AUTO_INCREMENT NOT NULL,
                `player_and_games` JSON NOT NULL,
@@ -767,5 +768,14 @@ abstract class TDBMAbstractServiceTest extends TestCase
             $quotedData[$connection->quoteIdentifier($id)] = $value;
         }
         $connection->delete($connection->quoteIdentifier($tableName), $quotedData);
+    }
+
+    protected static function isMariaDb(Connection $connection): bool
+    {
+        if (!$connection->getDatabasePlatform() instanceof MySqlPlatform) {
+            return false;
+        }
+        $version = $connection->fetchColumn('SELECT VERSION()');
+        return stripos($version, 'maria') !== false;
     }
 }

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -92,6 +92,7 @@ use TheCodingMachine\TDBM\Utils\PathFinder\NoPathFoundException;
 use TheCodingMachine\TDBM\Utils\PathFinder\PathFinder;
 use TheCodingMachine\TDBM\Utils\TDBMDaoGenerator;
 use Symfony\Component\Process\Process;
+use function get_class;
 
 class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
 {
@@ -2282,7 +2283,7 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
 
     public function testGeneratedColumnsAreNotPartOfTheConstructor(): void
     {
-        if ($this->tdbmService->getConnection()->getDatabasePlatform() instanceof MySqlPlatform && !self::isMariaDb($this->tdbmService->getConnection())) {
+        if (!$this->tdbmService->getConnection()->getDatabasePlatform() instanceof MySqlPlatform || self::isMariaDb($this->tdbmService->getConnection())) {
             $this->markTestSkipped('ReadOnly column is only tested with MySQL');
         }
 
@@ -2318,7 +2319,7 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
 
     public function testCanReadVirtualColumn(): void
     {
-        if ($this->tdbmService->getConnection()->getDatabasePlatform() instanceof MySqlPlatform && !self::isMariaDb($this->tdbmService->getConnection())) {
+        if (!$this->tdbmService->getConnection()->getDatabasePlatform() instanceof MySqlPlatform || self::isMariaDb($this->tdbmService->getConnection())) {
             $this->markTestSkipped('ReadOnly column is only tested with MySQL');
         }
 

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -2282,6 +2282,10 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
 
     public function testGeneratedColumnsAreNotPartOfTheConstructor(): void
     {
+        if ($this->tdbmService->getConnection()->getDatabasePlatform() instanceof MySqlPlatform && !self::isMariaDb($this->tdbmService->getConnection())) {
+            $this->markTestSkipped('ReadOnly column is only tested with MySQL');
+        }
+
         $dao = new PlayerDao($this->tdbmService);
 
         $player = new PlayerBean([
@@ -2314,6 +2318,10 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
 
     public function testCanReadVirtualColumn(): void
     {
+        if ($this->tdbmService->getConnection()->getDatabasePlatform() instanceof MySqlPlatform && !self::isMariaDb($this->tdbmService->getConnection())) {
+            $this->markTestSkipped('ReadOnly column is only tested with MySQL');
+        }
+
         $dao = new PlayerDao($this->tdbmService);
 
         $player = $dao->getById(1);

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -66,6 +66,7 @@ use TheCodingMachine\TDBM\Test\Dao\Bean\Generated\UserBaseBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\InheritedObjectBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\NodeBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\PersonBean;
+use TheCodingMachine\TDBM\Test\Dao\Bean\PlayerBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\RefNoPrimKeyBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\RoleBean;
 use TheCodingMachine\TDBM\Test\Dao\Bean\StateBean;
@@ -82,6 +83,7 @@ use TheCodingMachine\TDBM\Test\Dao\Generated\UserBaseDao;
 use TheCodingMachine\TDBM\Test\Dao\InheritedObjectDao;
 use TheCodingMachine\TDBM\Test\Dao\NodeDao;
 use TheCodingMachine\TDBM\Test\Dao\PersonDao;
+use TheCodingMachine\TDBM\Test\Dao\PlayerDao;
 use TheCodingMachine\TDBM\Test\Dao\RefNoPrimKeyDao;
 use TheCodingMachine\TDBM\Test\Dao\RoleDao;
 use TheCodingMachine\TDBM\Test\Dao\StateDao;
@@ -2276,5 +2278,45 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
 
         $this->assertNotNull($objects->first());
         $this->assertEquals(6, $objects->count());
+    }
+
+    public function testGeneratedColumnsAreNotPartOfTheConstructor(): void
+    {
+        $dao = new PlayerDao($this->tdbmService);
+
+        $player = new PlayerBean([
+            'id' => 1,
+            'name' => 'Sally',
+            'games_played' =>
+                [
+                    'Battlefield' =>
+                        [
+                            'weapon' => 'sniper rifle',
+                            'rank' => 'Sergeant V',
+                            'level' => 20,
+                        ],
+                    'Crazy Tennis' =>
+                        [
+                            'won' => 4,
+                            'lost' => 1,
+                        ],
+                    'Puzzler' =>
+                        [
+                            'time' => 7,
+                        ],
+                ],
+        ]);
+
+        $dao->save($player);
+
+        $this->assertTrue(true);
+    }
+
+    public function testCanReadVirtualColumn(): void
+    {
+        $dao = new PlayerDao($this->tdbmService);
+
+        $player = $dao->getById(1);
+        $this->assertSame('Sally', $player->getNamesVirtual());
     }
 }


### PR DESCRIPTION
The goal of this annotation is to make a column completely disappear from the constructor and from the setter.
This is useful for computed/generated columns that are dynamically computed by the DBMS.

Closes #214 