### PR TITLE
Making sure CI runs on push on master

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,9 @@ name: "Continuous Integration"
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   coding-standards:


### PR DESCRIPTION
This is needed by codecov, otherwise, we can't have a code coverage comparison.