### PR TITLE
Fix/deeper composite fk

### DIFF
--- a/src/Utils/AbstractBeanPropertyDescriptor.php
+++ b/src/Utils/AbstractBeanPropertyDescriptor.php
@@ -67,7 +67,7 @@ abstract class AbstractBeanPropertyDescriptor implements MethodDescriptorInterfa
      */
     public function getParamAnnotation(): ParamTag
     {
-        return new ParamTag($this->getVariableName(), [ $this->getPhpType() ]);
+        return new ParamTag($this->getSafeVariableName(), [ $this->getPhpType() ]);
     }
 
     public function getVariableName(): string

--- a/src/Utils/ObjectBeanPropertyDescriptor.php
+++ b/src/Utils/ObjectBeanPropertyDescriptor.php
@@ -270,9 +270,8 @@ PHP;
                 if ($shouldFlatten) {
                     $rows[] = trim($descriptor->getLazySerializeCode($propertyAccess), '[]');
                 } else {
-                    $varName = $descriptor->getSafeVariableName();
-                    $lazySerializeCode = $descriptor->getLazySerializeCode($varName);
-                    $rows[] = "'$indexName' => ($varName = $propertyAccess->$columnGetterName()) ? $lazySerializeCode : null";
+                    $lazySerializeCode = $descriptor->getLazySerializeCode("$propertyAccess->$columnGetterName()");
+                    $rows[] = "'$indexName' => $lazySerializeCode";
                 }
             } elseif ($descriptor instanceof ScalarBeanPropertyDescriptor) {
                 $rows[] = "'$indexName' => $propertyAccess->$columnGetterName()";

--- a/src/Utils/ObjectBeanPropertyDescriptor.php
+++ b/src/Utils/ObjectBeanPropertyDescriptor.php
@@ -258,15 +258,22 @@ PHP;
         $rows = [];
         foreach ($this->getForeignKey()->getUnquotedForeignColumns() as $column) {
             $descriptor = $this->getBeanPropertyDescriptor($column);
+            $shouldFlatten = false;
             if ($descriptor instanceof InheritanceReferencePropertyDescriptor) {
                 $descriptor = $descriptor->getNonScalarReferencedPropertyDescriptor();
+                $shouldFlatten = true;
             }
+
             $indexName = ltrim($descriptor->getVariableName(), '$');
             $columnGetterName = $descriptor->getGetterName();
             if ($descriptor instanceof ObjectBeanPropertyDescriptor) {
-                $varName = '$o' . lcfirst($indexName);
-                $lazySerializeCode = $descriptor->getLazySerializeCode($varName);
-                $rows[] = "'$indexName' => ($varName = $propertyAccess->$columnGetterName()) ? $lazySerializeCode : null";
+                if ($shouldFlatten) {
+                    $rows[] = trim($descriptor->getLazySerializeCode($propertyAccess), '[]');
+                } else {
+                    $varName = $descriptor->getSafeVariableName();
+                    $lazySerializeCode = $descriptor->getLazySerializeCode($varName);
+                    $rows[] = "'$indexName' => ($varName = $propertyAccess->$columnGetterName()) ? $lazySerializeCode : null";
+                }
             } elseif ($descriptor instanceof ScalarBeanPropertyDescriptor) {
                 $rows[] = "'$indexName' => $propertyAccess->$columnGetterName()";
             } else {
@@ -279,10 +286,10 @@ PHP;
     private function getBeanPropertyDescriptor(string $column): AbstractBeanPropertyDescriptor
     {
         foreach ($this->foreignBeanDescriptor->getBeanPropertyDescriptors() as $descriptor) {
-            if ($descriptor instanceof ObjectBeanPropertyDescriptor && in_array($column, $descriptor->getForeignKey()->getLocalColumns(), true)) {
+            if ($descriptor instanceof ScalarBeanPropertyDescriptor && $descriptor->getColumnName() === $column) {
                 return $descriptor;
             }
-            if ($descriptor instanceof ScalarBeanPropertyDescriptor && $descriptor->getColumnName() === $column) {
+            if ($descriptor instanceof ObjectBeanPropertyDescriptor && in_array($column, $descriptor->getForeignKey()->getLocalColumns(), true)) {
                 return $descriptor;
             }
         }

--- a/tests/TDBMAbstractServiceTest.php
+++ b/tests/TDBMAbstractServiceTest.php
@@ -458,8 +458,12 @@ abstract class TDBMAbstractServiceTest extends TestCase
             ->column('id')->integer()->primaryKey()->autoIncrement()
             ->column('base_object_id')->references('base_objects')->unique()->comment('@JsonCollection');
 
+        $db->table('composite_fk_target_reference')
+            ->column('id')->integer()->primaryKey()->autoIncrement()
+            ->column('label')->string();
+
         $targetTable = $db->table('composite_fk_target')
-            ->column('id_1')->integer()
+            ->column('id_1')->references('composite_fk_target_reference')
             ->column('id_2')->integer()
             ->then()->primaryKey(['id_1', 'id_2']);
         $db->table('composite_fk_source')
@@ -799,6 +803,10 @@ abstract class TDBMAbstractServiceTest extends TestCase
         self::insert($connection, 'person_boats', [
             'person_id' => 1,
             'boat_id' => 1,
+        ]);
+        self::insert($connection, 'composite_fk_target_reference', [
+            'id' => 1,
+            'label' => 'test'
         ]);
         self::insert($connection, 'composite_fk_target', [
             'id_1' => 1,

--- a/tests/TDBMDaoGeneratorTest.php
+++ b/tests/TDBMDaoGeneratorTest.php
@@ -2165,7 +2165,7 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
         $compositeFkSourceDao = new CompositeFkSourceDao($this->tdbmService);
         $compositeFkSourceBean = $compositeFkSourceDao->getById(1);
         $json = $compositeFkSourceBean->jsonSerialize(true);
-        $this->assertEquals(1, $json['compositeFkTarget']['id1']);
+        $this->assertEquals(1, $json['compositeFkTarget']['1']['id']);
         $this->assertEquals(1, $json['compositeFkTarget']['id2']);
     }
 


### PR DESCRIPTION
Fixes #207 

This fixes a corner case in serialization code about a schema looking like:
```
  summary_tdh  |  summary     |  entity
  entity_id   <=> entity_id  <=> entity_id
  summary_id  <=> summary_id
```
Where `<=>` reflects a Foreign Key