### PR TITLE
Improvement - Do not use alternative method name for first occurrence

### DIFF
--- a/src/Utils/BeanDescriptor.php
+++ b/src/Utils/BeanDescriptor.php
@@ -470,9 +470,17 @@ class BeanDescriptor implements BeanDescriptorInterface
             $this->descriptorsByMethodName[$name] = [];
         }
         $this->descriptorsByMethodName[$name][] = $descriptor;
-        if (count($this->descriptorsByMethodName[$name]) > 1) {
-            foreach ($this->descriptorsByMethodName[$name] as $duplicateDescriptor) {
-                $duplicateDescriptor->useAlternativeName();
+        $descriptors = $this->descriptorsByMethodName[$name];
+        if (count($descriptors) > 1) {
+            $properties = array_filter($descriptors, function ($descriptor) {
+                return $descriptor instanceof AbstractBeanPropertyDescriptor;
+            });
+            $renameProperties = count($properties) > 1;
+
+            foreach ($descriptors as $descriptor) {
+                if ($renameProperties || !$descriptor instanceof AbstractBeanPropertyDescriptor) {
+                    $descriptor->useAlternativeName();
+                }
             }
         }
     }


### PR DESCRIPTION
This is a proposition, not breaking current tests, but leading to potential breaking changes for people using this package.
Considering this schema:
```php
$db->table('foo')
  ->id()
  ->column('bar_id')->references('bar');
$db->table('bar')
  ->id()
  ->column('foo_id')->references('foo')->unique();
```
Current code will generate getters `FooBaseBean::getBarObject()` and `FooBaseBean::getBarByUniqueFooId()`, whether this request aims to generate `FooBaseBean::getBar()` instead of `FooBaseBean::getBarObject()`. Same transformation applies for setter and Json serialization.