### PR TITLE
Dist - Exclude test/CI files from composer archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,5 +87,8 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "archive": {
+        "exclude": ["/.github", "/tests", "/travis", "/vendor-bin", "/.*", "/composer-require-checker.json", "/couscous.yml", "/phpbench.*", "/phpstan.neon", "/phpunit.*"]
+    }
 }


### PR DESCRIPTION
Unless test classes are actually used in other projects tests, which seems like a very bad habit to me, I think we don't need to distribute them. Same goes for code checks. Only doubt is the exclusion of all hidden files (`.*`)