### PR TITLE
Fix - Foreign key broken when referenced table inherits another with pk renamed

### DIFF
--- a/src/DbRow.php
+++ b/src/DbRow.php
@@ -397,15 +397,16 @@ class DbRow
 
             if ($reference !== null) {
                 $refDbRows = $reference->_getDbRows();
-                $firstRefDbRow = reset($refDbRows);
-                if ($firstRefDbRow === false) {
+                $refDbRow = $refDbRows[$fk->getForeignTableName()] ?? false;
+
+                if ($refDbRow === false) {
                     throw new \RuntimeException('Unexpected error: empty refDbRows'); // @codeCoverageIgnore
                 }
-                if ($firstRefDbRow->_getStatus() === TDBMObjectStateEnum::STATE_DELETED) {
+                if ($refDbRow->_getStatus() === TDBMObjectStateEnum::STATE_DELETED) {
                     throw TDBMMissingReferenceException::referenceDeleted($this->dbTableName, $reference);
                 }
                 $foreignColumns = $fk->getUnquotedForeignColumns();
-                $refBeanValues = $firstRefDbRow->dbRow;
+                $refBeanValues = $refDbRow->dbRow;
                 for ($i = 0, $count = \count($localColumns); $i < $count; ++$i) {
                     $dbRow[$localColumns[$i]] = $refBeanValues[$foreignColumns[$i]];
                 }


### PR DESCRIPTION
Issue fixed by selecting the suitable DB row amongst many, instead of using the first by default, given that its primary key columns may use different names.