### PR TITLE
PHPStan - Fix `class-string` parameters

### DIFF
--- a/src/AbstractTDBMObject.php
+++ b/src/AbstractTDBMObject.php
@@ -251,6 +251,10 @@ abstract class AbstractTDBMObject implements JsonSerializable
         }
     }
 
+    /**
+     * @param class-string $className
+     * @param class-string $resultIteratorClass
+     */
     protected function setRef(string $foreignKeyName, ?AbstractTDBMObject $bean, string $tableName, string $className, string $resultIteratorClass): void
     {
         assert($bean === null || is_a($bean, $className), new TDBMInvalidArgumentException('$bean should be `null` or `' . $className . '`. `' . ($bean === null ? 'null' : get_class($bean)) . '` provided.'));
@@ -276,6 +280,8 @@ abstract class AbstractTDBMObject implements JsonSerializable
 
     /**
      * @param string $foreignKeyName A unique name for this reference
+     * @param class-string $className
+     * @param class-string $resultIteratorClass
      *
      * @return AbstractTDBMObject|null
      */

--- a/src/DbRow.php
+++ b/src/DbRow.php
@@ -262,6 +262,8 @@ class DbRow
 
     /**
      * @param string $foreignKeyName A unique name for this reference
+     * @param class-string $className
+     * @param class-string $resultIteratorClass
      *
      * @return AbstractTDBMObject|null
      */

--- a/src/ResultIterator.php
+++ b/src/ResultIterator.php
@@ -46,7 +46,7 @@ class ResultIterator implements Result, \ArrayAccess, \JsonSerializable
 
     /** @var ObjectStorageInterface */
     private $objectStorage;
-    /** @var string|null */
+    /** @var class-string|null */
     private $className;
 
     /** @var TDBMService */
@@ -77,6 +77,7 @@ class ResultIterator implements Result, \ArrayAccess, \JsonSerializable
 
     /**
      * @param mixed[] $parameters
+     * @param class-string|null $className
      */
     public static function createResultIterator(QueryFactory $queryFactory, array $parameters, ObjectStorageInterface $objectStorage, ?string $className, TDBMService $tdbmService, MagicQuery $magicQuery, int $mode, LoggerInterface $logger): self
     {

--- a/src/TDBMService.php
+++ b/src/TDBMService.php
@@ -364,6 +364,13 @@ class TDBMService
                     $filter = SafeFunctions::arrayCombine($incomingFk->getUnquotedLocalColumns(), $pks);
 
                     $localTableName = $incomingFk->getLocalTableName();
+
+                    $className = $this->beanNamespace . '\\' . $this->namingStrategy->getBeanClassName($localTableName);
+                    assert(class_exists($className));
+
+                    $resultIteratorClassName = $this->resultIteratorNamespace . '\\' . $this->namingStrategy->getResultIteratorClassName($localTableName);
+                    assert(class_exists($resultIteratorClassName));
+
                     $results = $this->findObjects(
                         $localTableName,
                         $filter,
@@ -371,8 +378,8 @@ class TDBMService
                         null,
                         [],
                         null,
-                        $this->beanNamespace . '\\' . $this->namingStrategy->getBeanClassName($localTableName),
-                        $this->resultIteratorNamespace . '\\' . $this->namingStrategy->getResultIteratorClassName($localTableName)
+                        $className,
+                        $resultIteratorClassName
                     );
 
                     foreach ($results as $bean) {
@@ -1136,8 +1143,8 @@ class TDBMService
      * @param string|UncheckedOrderBy|null $orderString           The ORDER BY part of the query. Columns from tables different from $mainTable must be prefixed by the table name (in the form: table.column)
      * @param string[]                     $additionalTablesFetch
      * @param int|null                     $mode
-     * @param string                       $className             Optional: The name of the class to instantiate. This class must extend the TDBMObject class. If none is specified, a TDBMObject instance will be returned
-     * @param string                       $resultIteratorClass   The name of the resultIterator class to return
+     * @param class-string|null            $className             Optional: The name of the class to instantiate. This class must extend the TDBMObject class. If none is specified, a TDBMObject instance will be returned
+     * @param class-string                 $resultIteratorClass   The name of the resultIterator class to return
      *
      * @return ResultIterator An object representing an array of results
      *
@@ -1173,8 +1180,8 @@ class TDBMService
      * @param mixed[]                      $parameters
      * @param string|UncheckedOrderBy|null $orderString The ORDER BY part of the query. All columns must be prefixed by the table name (in the form: table.column)
      * @param int                          $mode
-     * @param string                       $className   Optional: The name of the class to instantiate. This class must extend the TDBMObject class. If none is specified, a TDBMObject instance will be returned
-     * @param string                       $resultIteratorClass   The name of the resultIterator class to return
+     * @param class-string|null            $className   Optional: The name of the class to instantiate. This class must extend the TDBMObject class. If none is specified, a TDBMObject instance will be returned
+     * @param class-string                 $resultIteratorClass   The name of the resultIterator class to return
      *
      * @return ResultIterator An object representing an array of results
      *
@@ -1208,7 +1215,7 @@ class TDBMService
      * @param mixed[] $primaryKeys
      * @param string[] $additionalTablesFetch
      * @param bool $lazy Whether to perform lazy loading on this object or not
-     * @phpstan-param  class-string|null $className
+     * @phpstan-param  class-string $className
      *
      * @return AbstractTDBMObject
      *
@@ -1265,7 +1272,8 @@ class TDBMService
      * @param string|array|null $filter                The SQL filters to apply to the query (the WHERE part). All columns must be prefixed by the table name (in the form: table.column)
      * @param mixed[]           $parameters
      * @param string[]          $additionalTablesFetch
-     * @param string            $className             The name of the class to instantiate. This class must extend the TDBMObject class. If none is specified, a TDBMObject instance will be returned
+     * @param class-string      $className             The name of the class to instantiate. This class must extend the TDBMObject class. If none is specified, a TDBMObject instance will be returned
+     * @param class-string      $resultIteratorClass
      *
      * @return AbstractTDBMObject|null The object we want, or null if no object matches the filters
      *
@@ -1321,7 +1329,8 @@ class TDBMService
      * @param string            $from       The from sql statement
      * @param string|array|null $filter     The SQL filters to apply to the query (the WHERE part). All columns must be prefixed by the table name (in the form: table.column)
      * @param mixed[]           $parameters
-     * @param string            $className  Optional: The name of the class to instantiate. This class must extend the TDBMObject class. If none is specified, a TDBMObject instance will be returned
+     * @param class-string|null $className  Optional: The name of the class to instantiate. This class must extend the TDBMObject class. If none is specified, a TDBMObject instance will be returned
+     * @param class-string      $resultIteratorClass
      *
      * @return AbstractTDBMObject|null The object we want, or null if no object matches the filters
      *
@@ -1339,9 +1348,9 @@ class TDBMService
      * @param string $sql
      * @param mixed[] $parameters
      * @param int|null $mode
-     * @param string|null $className
+     * @param class-string|null $className
      * @param string $sqlCount
-     * @param string $resultIteratorClass The name of the resultIterator class to return
+     * @param class-string $resultIteratorClass The name of the resultIterator class to return
      *
      * @return ResultIterator
      *
@@ -1372,7 +1381,8 @@ class TDBMService
      * @param string|array|null $filter                The SQL filters to apply to the query (the WHERE part). All columns must be prefixed by the table name (in the form: table.column)
      * @param mixed[]           $parameters
      * @param string[]          $additionalTablesFetch
-     * @param string            $className             The name of the class to instantiate. This class must extend the TDBMObject class. If none is specified, a TDBMObject instance will be returned
+     * @param class-string      $className             The name of the class to instantiate. This class must extend the TDBMObject class. If none is specified, a TDBMObject instance will be returned
+     * @param class-string      $resultIteratorClass
      *
      * @return AbstractTDBMObject The object we want
      *

--- a/src/Utils/BeanDescriptor.php
+++ b/src/Utils/BeanDescriptor.php
@@ -607,6 +607,7 @@ class BeanDescriptor implements BeanDescriptorInterface
             $class->setExtendedClass(AbstractTDBMObject::class);
             $file->setUse(AbstractTDBMObject::class);
         } else {
+            /** @var class-string $extends */
             $class->setExtendedClass($extends);
         }
 
@@ -1190,6 +1191,7 @@ EOF
             $class->setExtendedClass(ResultIterator::class);
         } else {
             $class->addUse($this->resultIteratorNamespace . '\\' . $extends);
+            /** @var class-string $extends */
             $class->setExtendedClass($extends);
         }
 

--- a/src/Utils/ManyToManyRelationshipPathDescriptor.php
+++ b/src/Utils/ManyToManyRelationshipPathDescriptor.php
@@ -31,7 +31,7 @@ class ManyToManyRelationshipPathDescriptor
      */
     private $whereKeys;
     /**
-     * @var string
+     * @var class-string
      */
     private $resultIteratorClass;
 
@@ -42,6 +42,7 @@ class ManyToManyRelationshipPathDescriptor
      * @param string[] $joinForeignKeys
      * @param string[] $joinLocalKeys
      * @param string[] $whereKeys
+     * @param class-string $resultIteratorClass
      */
     public function __construct(string $targetTable, string $pivotTable, array $joinForeignKeys, array $joinLocalKeys, array $whereKeys, string $resultIteratorClass)
     {
@@ -104,6 +105,9 @@ class ManyToManyRelationshipPathDescriptor
         return $params;
     }
 
+    /**
+     * @return class-string
+     */
     public function getResultIteratorClass(): string
     {
         return $this->resultIteratorClass;


### PR DESCRIPTION
- Add missing/Fix wrong declarations in function signatures (mostly `$beanClasse`/`$resultIteratorClass`)
- Add assert when building class strings from concatenation
- Bypass check in code generator (since `use` statement distorts `class-string` expectation from Laminas' class generator)