### PR TITLE
Adding mixed return type to bean's jsonSerialize

### DIFF
--- a/src/Utils/BeanDescriptor.php
+++ b/src/Utils/BeanDescriptor.php
@@ -515,6 +515,13 @@ class BeanDescriptor implements BeanDescriptorInterface
         ));
         $method->setParameter(new ParameterGenerator('stopRecursion', 'bool', false));
 
+        /*
+         * Set jsonSerialize's mixed return type for php >= 8
+         */
+        if (version_compare(PHP_VERSION, '8.0.0', '>=')) {
+            $method->setReturnType("mixed");
+        }
+
         if ($parentFk !== null) {
             $body = '$array = parent::jsonSerialize($stopRecursion);';
         } else {


### PR DESCRIPTION
 To fully support post php7 version, jsonSerialize's signature need to be as "mixed"
 See documentation at: https://www.php.net/manual/fr/jsonserializable.jsonserialize.php
 
 This PR allow PHP8's Opcache preloading to run on symfony when using TDBM (as in https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading)