### PR TITLE
Chore - Replace Porpaginas with self-owned code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "doctrine/dbal": "^2.9.2",
         "psr/log": "~1.0",
         "doctrine/inflector": "^1.4.3 || ^2",
-        "beberlei/porpaginas": "~1.0",
         "mouf/classname-mapper": "~1.0",
         "doctrine/cache": "^1.6",
         "greenlion/php-sql-parser": "^4.3.0",

--- a/doc/limit_offset_resultset.md
+++ b/doc/limit_offset_resultset.md
@@ -112,16 +112,6 @@ Pages (retrieved with the `take` method) also have additional methods you can ca
 - `map(callable $callback)`: will call the `$callback` on every bean of the page and return the matching array.
 
 
-Implements Porpiginas
----------------------
-
-If you are already familiar with [beberlei/porpaginas](https://github.com/beberlei/porpaginas), you probably noticed
-that TDBM result sets implement Porpaginas interfaces (the `Result` and `Page` concept comes from Porpaginas).
-
-This means that you can easily migrate to and from any ORM that uses Porpaginas for its results. You can also
-use any pagination library compatible with Porpaginas, like Pagerfanta.
-
-
 Next step
 ---------
 

--- a/src/AlterableResultIterator.php
+++ b/src/AlterableResultIterator.php
@@ -3,17 +3,13 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\TDBM;
 
-use Porpaginas\Arrays\ArrayPage;
-use Porpaginas\Iterator;
-use Porpaginas\Result;
-
 /**
  * This class acts as a wrapper around a result iterator.
  * It can be used to add or remove results from a ResultIterator (or any kind a traversable collection).
  *
  * Note: in the case of TDBM, this is useful to manage many to one relationships
  */
-class AlterableResultIterator implements Result, \ArrayAccess, \JsonSerializable
+class AlterableResultIterator implements ResultInterface, \ArrayAccess, \JsonSerializable
 {
     /**
      * @var \Traversable|null
@@ -201,16 +197,10 @@ class AlterableResultIterator implements Result, \ArrayAccess, \JsonSerializable
         throw new TDBMInvalidOperationException('You can unset values in a TDBM result set, even in an alterable one. Use the delete method instead.');
     }
 
-    /**
-     * @param int $offset
-     * @param int $limit
-     *
-     * @return \Porpaginas\Page
-     */
-    public function take($offset, $limit)
+    public function take(int $offset, int $limit): PageInterface
     {
         // TODO: replace this with a class implementing the map method.
-        return new ArrayPage(array_slice($this->toArray(), $offset, $limit), $offset, $limit, count($this->toArray()));
+        return new PageArray(array_slice($this->toArray(), $offset, $limit), $offset, $limit, count($this->toArray()));
     }
 
     /**

--- a/src/PageArray.php
+++ b/src/PageArray.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\TDBM;
+
+use ArrayIterator;
+use Traversable;
+
+class PageArray implements PageInterface
+{
+    private array $items;
+    private int $offset;
+    private int $limit;
+    private int $totalCount;
+
+    /**
+     * @param array $items
+     */
+    public function __construct(array $items, int $offset, int $limit, int $totalCount)
+    {
+        $this->items = $items;
+        $this->offset = $offset;
+        $this->limit = $limit;
+        $this->totalCount = $totalCount;
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    public function totalCount(): int
+    {
+        return $this->totalCount;
+    }
+
+    public function getCurrentOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function getCurrentPage(): int
+    {
+        return (int) floor($this->offset / $this->limit) + 1;
+    }
+
+    public function getCurrentLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+}

--- a/src/PageInterface.php
+++ b/src/PageInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\TDBM;
+
+use Countable;
+use IteratorAggregate;
+
+interface PageInterface extends Countable, IteratorAggregate
+{
+    /**
+     * Returns the total number of results in the paginated collection.
+     */
+    public function totalCount(): int;
+
+    public function getCurrentOffset(): int;
+
+    public function getCurrentPage(): int;
+
+    public function getCurrentLimit(): int;
+}

--- a/src/PageIterator.php
+++ b/src/PageIterator.php
@@ -5,7 +5,6 @@ namespace TheCodingMachine\TDBM;
 
 use Doctrine\DBAL\Statement;
 use Mouf\Database\MagicQuery;
-use Porpaginas\Page;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -30,7 +29,7 @@ use Psr\Log\NullLogger;
 /**
  * Iterator used to retrieve results.
  */
-class PageIterator implements Page, \ArrayAccess, \JsonSerializable
+class PageIterator implements PageInterface, \ArrayAccess, \JsonSerializable
 {
     /** @var Statement */
     protected $statement;
@@ -132,46 +131,33 @@ class PageIterator implements Page, \ArrayAccess, \JsonSerializable
         return $this->innerResultIterator;
     }
 
-    /**
-     * @return int
-     */
-    public function getCurrentOffset()
+    public function getCurrentOffset(): int
     {
         return $this->offset;
     }
 
-    /**
-     * @return int
-     */
-    public function getCurrentPage()
+    public function getCurrentPage(): int
     {
         return (int) floor($this->offset / $this->limit) + 1;
     }
 
-    /**
-     * @return int
-     */
-    public function getCurrentLimit()
+    public function getCurrentLimit(): int
     {
         return $this->limit;
     }
 
     /**
      * Return the number of results on the current page of the {@link Result}.
-     *
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->getIterator()->count();
     }
 
     /**
      * Return the number of ALL results in the paginatable of {@link Result}.
-     *
-     * @return int
      */
-    public function totalCount()
+    public function totalCount(): int
     {
         return $this->parentResult->count();
     }

--- a/src/ResultInterface.php
+++ b/src/ResultInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\TDBM;
+
+use Countable;
+use IteratorAggregate;
+
+interface ResultInterface extends Countable, IteratorAggregate
+{
+    public function take(int $offset, int $limit): PageInterface;
+}

--- a/src/ResultIterator.php
+++ b/src/ResultIterator.php
@@ -13,7 +13,6 @@ use function is_array;
 use function is_int;
 use Mouf\Database\MagicQuery;
 use TheCodingMachine\TDBM\QueryFactory\QueryFactory;
-use Porpaginas\Result;
 use Psr\Log\LoggerInterface;
 use TheCodingMachine\TDBM\Utils\DbalUtils;
 use Traversable;
@@ -39,7 +38,7 @@ use Traversable;
 /**
  * Iterator used to retrieve results.
  */
-class ResultIterator implements Result, \ArrayAccess, \JsonSerializable
+class ResultIterator implements ResultInterface, \ArrayAccess, \JsonSerializable
 {
     /** @var Statement */
     protected $statement;
@@ -174,13 +173,7 @@ class ResultIterator implements Result, \ArrayAccess, \JsonSerializable
         return $this->innerResultIterator;
     }
 
-    /**
-     * @param int $offset
-     * @param int $limit
-     *
-     * @return PageIterator
-     */
-    public function take($offset, $limit)
+    public function take(int $offset, int $limit): PageIterator
     {
         if ($this->totalCount === 0) {
             return PageIterator::createEmpyIterator($this);

--- a/tests/Dao/TestCountryDao.php
+++ b/tests/Dao/TestCountryDao.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\TDBM\Dao;
 
-use Porpaginas\Result;
+use TheCodingMachine\TDBM\ResultInterface;
 use TheCodingMachine\TDBM\Test\Dao\Bean\CountryBean;
 use TheCodingMachine\TDBM\Test\Dao\Generated\CountryBaseDao;
 
@@ -13,7 +13,7 @@ use TheCodingMachine\TDBM\Test\Dao\Generated\CountryBaseDao;
 class TestCountryDao extends CountryBaseDao
 {
     /**
-     * @return CountryBean[]|Result
+     * @return CountryBean[]|ResultInterface
      */
     public function getCountriesByUserCount()
     {
@@ -29,7 +29,7 @@ SQL;
     }
 
     /**
-     * @return CountryBean[]|Result
+     * @return CountryBean[]|ResultInterface
      */
     public function getCountriesUsingUnion()
     {
@@ -47,7 +47,7 @@ SQL;
     }
 
     /**
-     * @return CountryBean[]|Result
+     * @return CountryBean[]|ResultInterface
      */
     public function getCountriesUsingSimpleQuery()
     {
@@ -61,7 +61,7 @@ SQL;
     }
 
     /**
-     * @return CountryBean[]|Result
+     * @return CountryBean[]|ResultInterface
      */
     public function getCountriesUsingDistinctQuery()
     {

--- a/tests/TDBMServiceTest.php
+++ b/tests/TDBMServiceTest.php
@@ -247,7 +247,7 @@ JOIN users ON country.id= users.country_id
 GROUP BY country.id
 HAVING COUNT(users.id) > 1;
 SQL;
-        /** @var Test\Dao\Bean\CountryBean[]|\Porpaginas\Result $beans */
+        /** @var Test\Dao\Bean\CountryBean[]|ResultInterface $beans */
         $beans = $this->tdbmService->findObjectsFromRawSql('country', $sql, [], null, Test\Dao\Bean\CountryBean::class, null, CountryResultIterator::class);
 
         $count = 0;
@@ -270,7 +270,7 @@ GROUP BY country.id
 ORDER BY COUNT(users.id);
 SQL;
 
-        /** @var Test\Dao\Bean\CountryBean[]|\Porpaginas\Result $beans */
+        /** @var Test\Dao\Bean\CountryBean[]|ResultInterface $beans */
         $beans = $this->tdbmService->findObjectsFromRawSql('country', $sql, [], null, Test\Dao\Bean\CountryBean::class, null, CountryResultIterator::class);
 
         $count = 0;
@@ -299,7 +299,7 @@ GROUP BY users.id
 ORDER BY MAX(IF(roles.name = 'Admins', 3, IF(roles.name = 'Writers', 2, IF(roles.name = 'Singers', 1, 0)))) DESC
 SQL;
 
-        /** @var Test\Dao\Bean\UserBean[]|\Porpaginas\Result $beans */
+        /** @var Test\Dao\Bean\UserBean[]|ResultInterface $beans */
         $beans = $this->tdbmService->findObjectsFromRawSql('contact', $sql, [], null, Test\Dao\Bean\UserBean::class, null, UserResultIterator::class);
 
         function getCustomOrder(Test\Dao\Bean\UserBean $contact)


### PR DESCRIPTION
[`beberlei/porpaginas`](https://github.com/beberlei/porpaginas) seems to be no longer maintained, and is incompatible with PHP 8.1, due to covariance violations with implemented native interfaces.

Consequently, this aims to replace the code used from Porpaginas (limited to a very small set of interfaces and classes) with self-owned code, compatible with PHP 8.1.