### PR TITLE
:sparkles: Add `TDBMService::clearBeanCache` method

### DIFF
--- a/src/NativeWeakrefObjectStorage.php
+++ b/src/NativeWeakrefObjectStorage.php
@@ -94,6 +94,14 @@ class NativeWeakrefObjectStorage implements ObjectStorageInterface
         unset($this->objects[$tableName][$id]);
     }
 
+    /**
+     * Removes all objects from the storage.
+     */
+    public function clear(): void
+    {
+        $this->objects = array();
+    }
+
     private function cleanupDanglingWeakRefs(): void
     {
         foreach ($this->objects as $tableName => $table) {

--- a/src/ObjectStorageInterface.php
+++ b/src/ObjectStorageInterface.php
@@ -41,4 +41,9 @@ interface ObjectStorageInterface
      * @param string|int $id
      */
     public function remove(string $tableName, $id): void;
+
+    /**
+     * Removes all objects from the storage.
+     */
+    public function clear(): void;
 }

--- a/src/TDBMService.php
+++ b/src/TDBMService.php
@@ -1559,4 +1559,14 @@ class TDBMService
     {
         $this->logger = new LevelFilter($this->rootLogger, $level);
     }
+
+    /**
+     * Clear TDBM's bean cache
+     *
+     * This can be used in long-running processes to cleanup everything.
+     */
+    public function clearBeanCache(): void
+    {
+        $this->objectStorage->clear();
+    }
 }


### PR DESCRIPTION
This method can be used to cleanup every bean so long-running process won't keep old data.