### PR TITLE
Fix: sort foreign keys in SchemaNormalizer to stabilize bean generation

### DIFF
--- a/src/SchemaVersionControl/SchemaNormalizer.php
+++ b/src/SchemaVersionControl/SchemaNormalizer.php
@@ -72,6 +72,9 @@ class SchemaNormalizer
         foreach ($table->getForeignKeys() as $foreignKey) {
             $tableDesc['foreign_keys'][$foreignKey->getName()] = $this->normalizeForeignKeyConstraint($foreignKey);
         }
+        if (isset($tableDesc['foreign_keys'])) {
+            ksort($tableDesc['foreign_keys']);
+        }
 
         return $tableDesc;
     }

--- a/tests/SchemaVersionControl/SchemaNormalizerTest.php
+++ b/tests/SchemaVersionControl/SchemaNormalizerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\TDBM\SchemaVersionControl;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaConfig;
+use PHPUnit\Framework\TestCase;
+
+class SchemaNormalizerTest extends TestCase
+{
+    public function testForeignKeysAreSortedAlphabetically(): void
+    {
+        $schema = new Schema();
+        $users = $schema->createTable('users');
+        $users->addColumn('id', 'integer');
+        $users->setPrimaryKey(['id']);
+
+        $reviews = $schema->createTable('reviews');
+        $reviews->addColumn('id', 'integer');
+        $reviews->addColumn('reviewed_by', 'integer');
+        $reviews->addColumn('reversed_by', 'integer');
+        $reviews->setPrimaryKey(['id']);
+        // Add in Z→A order to prove sorting is applied, not insertion order
+        $reviews->addForeignKeyConstraint('users', ['reversed_by'], ['id'], [], 'FK_ZZZ');
+        $reviews->addForeignKeyConstraint('users', ['reviewed_by'], ['id'], [], 'FK_AAA');
+
+        $normalizer = new SchemaNormalizer();
+        $result = $normalizer->normalize($schema, new SchemaConfig());
+
+        $fkKeys = array_keys($result['tables']['reviews']['foreign_keys']);
+        $this->assertSame(['FK_AAA', 'FK_ZZZ'], $fkKeys);
+    }
+}


### PR DESCRIPTION
When a table has two foreign keys pointing to the same target table, the generated Base bean methods for the reverse relation (one-to-many) were reordered on every `tdbm:generate` run.

Root cause: SchemaNormalizer::normalizeTable() wrote foreign_keys to the lock file in the order returned by DB introspection (AbstractSchemaManager::introspectSchema()). MySQL/MariaDB does not guarantee a stable ordering of FK constraints, so the lock file FK order could differ between environments or after schema changes. Since tdbm:generate writes the lock file then immediately reads it to generate beans, the bean method order inherited this non-determinism.

The post-processing normalize-tdbm-yaml.php script sorted the lock file after the fact, but beans were already generated by then.

Fix: apply ksort() on foreign_keys after collection in normalizeTable(), consistent with the existing ksort() on tables in normalize(). Guard with isset() for tables that have no foreign keys.